### PR TITLE
Add --report flag to write report.json / report.md (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ vercel-seo-audit https://yoursite.com --user-agent bingbot
 
 # Custom crawler user-agent
 vercel-seo-audit https://yoursite.com --user-agent "Googlebot-Image/1.0"
+
+# Write report to file (json or md)
+vercel-seo-audit https://yoursite.com --report json
+vercel-seo-audit https://yoursite.com --report md
 ```
 
 ---
@@ -191,7 +195,7 @@ jobs:
 * [x] ~~`--strict` (warnings fail with exit code 1)~~
 * [x] ~~`--pages` to customize sampled paths (`/about,/pricing`)~~
 * [x] ~~`--user-agent` presets (`googlebot`, `bingbot`)~~
-* [ ] `--report` to write `report.json` / `report.md`
+* [x] ~~`--report` to write `report.json` / `report.md`~~
 * [ ] GitHub Action marketplace wrapper
 
 ---


### PR DESCRIPTION
## Summary

- Add `--report <format>` CLI option (`json` or `md`)
- `--report json` writes `report.json` to cwd
- `--report md` writes `report.md` with markdown-formatted audit results
- Console output remains unchanged (file is written in addition)
- Invalid format values exit with code 2

Closes #10

## Test plan

- [ ] `--report json` writes valid `report.json`
- [ ] `--report md` writes readable `report.md` with summary table and categorized findings
- [ ] Console output still prints normally alongside file write
- [ ] Omitting `--report` keeps current behavior (no file written)
- [ ] `--report invalid` exits with error code 2
- [ ] `npm run build` passes
- [ ] `npm test` passes (14/14)