### PR TITLE
Add GitHub Action marketplace wrapper (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ For a deeper dive into why Next.js sites often struggle with indexing, see:
 ## Quick start
 
 ```bash
-npx vercel-seo-audit https://yoursite.com
+npx vercel-seo-audit https://yusufhan.dev
 ```
 
 Install globally (optional):
 
 ```bash
 npm i -g vercel-seo-audit
-vercel-seo-audit https://yoursite.com
+vercel-seo-audit https://yusufhan.dev
 ```
 
 ---
@@ -67,32 +67,32 @@ SEO Audit Report for https://yusufhan.dev/
 
 ```bash
 # Basic audit
-vercel-seo-audit https://yoursite.com
+vercel-seo-audit https://yusufhan.dev
 
 # JSON output (pipe to jq, save to file, feed to CI)
-vercel-seo-audit https://yoursite.com --json
+vercel-seo-audit https://yusufhan.dev --json
 
 # Verbose mode — raw HTTP details for each finding
-vercel-seo-audit https://yoursite.com --verbose
+vercel-seo-audit https://yusufhan.dev --verbose
 
 # Custom timeout (default: 10s)
-vercel-seo-audit https://yoursite.com --timeout 15000
+vercel-seo-audit https://yusufhan.dev --timeout 15000
 
 # Check specific pages for redirect issues
-vercel-seo-audit https://yoursite.com --pages /docs,/team,/careers
+vercel-seo-audit https://yusufhan.dev --pages /docs,/team,/careers
 
 # Audit as Googlebot
-vercel-seo-audit https://yoursite.com --user-agent googlebot
+vercel-seo-audit https://yusufhan.dev --user-agent googlebot
 
 # Audit as Bingbot
-vercel-seo-audit https://yoursite.com --user-agent bingbot
+vercel-seo-audit https://yusufhan.dev --user-agent bingbot
 
 # Custom crawler user-agent
-vercel-seo-audit https://yoursite.com --user-agent "Googlebot-Image/1.0"
+vercel-seo-audit https://yusufhan.dev --user-agent "Googlebot-Image/1.0"
 
 # Write report to file (json or md)
-vercel-seo-audit https://yoursite.com --report json
-vercel-seo-audit https://yoursite.com --report md
+vercel-seo-audit https://yusufhan.dev --report json
+vercel-seo-audit https://yusufhan.dev --report md
 ```
 
 ---
@@ -166,12 +166,44 @@ Exit codes:
 
 ## CI / GitHub Actions
 
-Fail the build only when **errors** exist:
+### Using the GitHub Action
 
 ```yaml
 name: SEO Audit
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JosephDoUrden/vercel-seo-audit@v1
+        with:
+          url: https://yusufhan.dev
+          strict: true
+          report: json
+```
+
+All inputs:
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `url` | yes | — | URL to audit |
+| `strict` | no | `false` | Fail on warnings too |
+| `user-agent` | no | — | `googlebot`, `bingbot`, or custom string |
+| `pages` | no | — | Comma-separated page paths |
+| `report` | no | — | Write report file: `json` or `md` |
+| `timeout` | no | `10000` | Request timeout in ms |
+| `verbose` | no | `false` | Show detailed output |
+
+Outputs: `exit-code`, `report-path`
+
+### Using npx directly
+
+```yaml
+name: SEO Audit
+on:
   push:
     branches: [main]
 
@@ -183,8 +215,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npx vercel-seo-audit https://yoursite.com --json
+      - run: npx vercel-seo-audit https://yusufhan.dev --json
 ```
+
 >[!TIP]
 >If you want warnings to fail CI too, add a `--strict` or `-S` flag.
 
@@ -196,7 +229,7 @@ jobs:
 * [x] ~~`--pages` to customize sampled paths (`/about,/pricing`)~~
 * [x] ~~`--user-agent` presets (`googlebot`, `bingbot`)~~
 * [x] ~~`--report` to write `report.json` / `report.md`~~
-* [ ] GitHub Action marketplace wrapper
+* [x] ~~GitHub Action marketplace wrapper~~
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,95 @@
+name: 'Vercel SEO Audit'
+description: 'Diagnose SEO and indexing issues for Next.js/Vercel websites'
+author: 'Yusufhan Sacak'
+branding:
+  icon: 'search'
+  color: 'blue'
+
+inputs:
+  url:
+    description: 'URL to audit (e.g. https://yusufhan.dev)'
+    required: true
+  strict:
+    description: 'Fail on warnings too (exit code 1)'
+    required: false
+    default: 'false'
+  user-agent:
+    description: 'User-Agent preset (googlebot, bingbot) or custom string'
+    required: false
+  pages:
+    description: 'Comma-separated page paths to check (e.g. /docs,/team)'
+    required: false
+  report:
+    description: 'Write report to file: json or md'
+    required: false
+  timeout:
+    description: 'Request timeout in milliseconds'
+    required: false
+    default: '10000'
+  verbose:
+    description: 'Show detailed information for each finding'
+    required: false
+    default: 'false'
+
+outputs:
+  exit-code:
+    description: 'Audit exit code (0 = pass, 1 = errors found, 2 = crash)'
+    value: ${{ steps.audit.outputs.exit-code }}
+  report-path:
+    description: 'Path to report file (if --report was used)'
+    value: ${{ steps.audit.outputs.report-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Run SEO Audit
+      id: audit
+      shell: bash
+      run: |
+        args="${{ inputs.url }}"
+
+        if [ "${{ inputs.strict }}" = "true" ]; then
+          args="$args --strict"
+        fi
+
+        if [ -n "${{ inputs.user-agent }}" ]; then
+          args="$args --user-agent \"${{ inputs.user-agent }}\""
+        fi
+
+        if [ -n "${{ inputs.pages }}" ]; then
+          args="$args --pages ${{ inputs.pages }}"
+        fi
+
+        if [ -n "${{ inputs.report }}" ]; then
+          args="$args --report ${{ inputs.report }}"
+        fi
+
+        if [ "${{ inputs.timeout }}" != "10000" ]; then
+          args="$args --timeout ${{ inputs.timeout }}"
+        fi
+
+        if [ "${{ inputs.verbose }}" = "true" ]; then
+          args="$args --verbose"
+        fi
+
+        set +e
+        eval npx vercel-seo-audit@latest $args
+        EXIT_CODE=$?
+        set -e
+
+        echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+        if [ -n "${{ inputs.report }}" ]; then
+          if [ "${{ inputs.report }}" = "json" ]; then
+            echo "report-path=report.json" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.report }}" = "md" ]; then
+            echo "report-path=report.md" >> "$GITHUB_OUTPUT"
+          fi
+        fi
+
+        exit $EXIT_CODE

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ program
   .name('vercel-seo-audit')
   .description('Diagnose SEO and indexing issues for Next.js/Vercel websites')
   .version('0.4.0')
-  .argument('<url>', 'URL to audit (e.g. https://example.com)')
+  .argument('<url>', 'URL to audit (e.g. https://yusufhan.dev)')
   .option('--json', 'Output results as JSON')
   .option('--verbose', 'Show detailed information for each finding')
   .option('-S, --strict', 'Fail on any SEO issues found, including warnings')


### PR DESCRIPTION
## Summary

- Add `action.yml` composite action wrapping the CLI with typed inputs/outputs
- Supports all CLI flags: `url`, `strict`, `user-agent`, `pages`, `report`, `timeout`, `verbose`
- Outputs `exit-code` and `report-path` for downstream steps
- Update all example URLs from `example.com`/`yoursite.com` to `yusufhan.dev`
- Update README CI section with GitHub Action usage + inputs table
- Mark roadmap item as complete

Closes #11

## Test plan

- [ ] Action runs successfully in a workflow with `uses: JosephDoUrden/vercel-seo-audit@v1`
- [ ] All inputs are correctly mapped to CLI flags
- [ ] `exit-code` output reflects audit result
- [ ] `report-path` output is set when `--report` is used
- [ ] `npm run build` passes
- [ ] `npm test` passes (14/14)