### PR TITLE
feat: add --diff flag to compare audit runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ vercel-seo-audit https://yusufhan.dev --user-agent "Googlebot-Image/1.0"
 # Write report to file (json or md)
 vercel-seo-audit https://yusufhan.dev --report json
 vercel-seo-audit https://yusufhan.dev --report md
+
+# Compare against a previous report to detect regressions
+vercel-seo-audit https://yusufhan.dev --diff previous-report.json
+
+# Diff with JSON output
+vercel-seo-audit https://yusufhan.dev --diff previous-report.json --json
 ```
 
 ---
@@ -230,7 +236,7 @@ jobs:
 * [x] ~~`--user-agent` presets (`googlebot`, `bingbot`)~~
 * [x] ~~`--report` to write `report.json` / `report.md`~~
 * [x] ~~GitHub Action marketplace wrapper~~
-* [ ] `--diff` to compare two audit runs and detect regressions
+* [x] ~~`--diff` to compare two audit runs and detect regressions~~
 * [ ] Structured data / JSON-LD validation
 * [ ] `--crawl` mode to audit all pages from sitemap
 * [ ] i18n / `hreflang` validation

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,12 @@ export interface AuditReport {
   modules: AuditModuleResult[];
 }
 
+export interface DiffResult {
+  newIssues: AuditFinding[];
+  resolvedIssues: AuditFinding[];
+  unchanged: AuditFinding[];
+}
+
 export interface RedirectHop {
   url: string;
   status: number;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { AuditFinding, AuditReport, IssueSeverity } from '../types.js';
+import type { AuditFinding, AuditReport, DiffResult, IssueSeverity } from '../types.js';
 
 const severityColors: Record<IssueSeverity, (text: string) => string> = {
   error: chalk.red,
@@ -150,4 +150,41 @@ export function formatMarkdown(report: AuditReport): string {
   }
 
   return lines.join('\n');
+}
+
+export function formatDiff(diff: DiffResult): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(chalk.bold.underline('Diff against previous report'));
+  lines.push('');
+  lines.push(
+    `  ${chalk.green(`+ ${diff.newIssues.length} new`)}  ` +
+    `${chalk.red(`- ${diff.resolvedIssues.length} resolved`)}  ` +
+    `${chalk.dim(`= ${diff.unchanged.length} unchanged`)}`
+  );
+  lines.push('');
+
+  if (diff.newIssues.length > 0) {
+    lines.push(chalk.green.bold('  New issues:'));
+    for (const f of diff.newIssues) {
+      const color = severityColors[f.severity];
+      lines.push(color(`    + [${f.severity.toUpperCase()}] ${f.message}${f.url ? ` (${f.url})` : ''}`));
+    }
+    lines.push('');
+  }
+
+  if (diff.resolvedIssues.length > 0) {
+    lines.push(chalk.red.bold('  Resolved issues:'));
+    for (const f of diff.resolvedIssues) {
+      lines.push(chalk.dim(`    - [${f.severity.toUpperCase()}] ${f.message}${f.url ? ` (${f.url})` : ''}`));
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export function formatDiffJson(diff: DiffResult): string {
+  return JSON.stringify(diff, null, 2);
 }


### PR DESCRIPTION
## Summary
- Adds `--diff <path>` CLI option to compare current audit against a previous `report.json`
- Detects new, resolved, and unchanged issues by matching on `code::url` keys
- Supports both colored console output and `--json` mode

## Changes
- `src/types.ts`: Added `DiffResult` interface
- `src/utils/output.ts`: Added `formatDiff()` and `formatDiffJson()` helpers
- `src/cli.ts`: Added `--diff` option with report loading, comparison logic, and output
- `README.md`: Added usage examples and marked roadmap item as complete

## Usage
```bash
# Generate baseline
vercel-seo-audit https://example.com --report json
mv report.json previous.json

# Compare against baseline
vercel-seo-audit https://example.com --diff previous.json

# JSON output
vercel-seo-audit https://example.com --diff previous.json --json
```

## Test plan
- [ ] Run audit with `--report json` to generate a baseline report
- [ ] Run audit with `--diff <path>` and verify new/resolved/unchanged output
- [ ] Run with `--diff <path> --json` and verify JSON diff output
- [ ] Verify `--diff` with invalid path shows error and exits with code 2
- [ ] Verify `npm run build` passes

Closes #14