### PR TITLE
feat: add HTML report format with interactive dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ vercel-seo-audit https://your-site.com --user-agent bingbot
 # Custom crawler user-agent
 vercel-seo-audit https://your-site.com --user-agent "Googlebot-Image/1.0"
 
-# Write report to file (json or md)
+# Write report to file (json, md, or html)
 vercel-seo-audit https://your-site.com --report json
 vercel-seo-audit https://your-site.com --report md
+vercel-seo-audit https://your-site.com --report html
 
 # Compare against a previous report to detect regressions
 vercel-seo-audit https://your-site.com --diff previous-report.json
@@ -290,7 +291,7 @@ All inputs:
 | `strict` | no | `false` | Fail on warnings too |
 | `user-agent` | no | — | `googlebot`, `bingbot`, or custom string |
 | `pages` | no | — | Comma-separated page paths |
-| `report` | no | — | Write report file: `json` or `md` |
+| `report` | no | — | Write report file: `json`, `md`, or `html` |
 | `crawl` | no | — | Crawl sitemap URLs (number = page limit, default 50) |
 | `timeout` | no | `10000` | Request timeout in ms |
 | `verbose` | no | `false` | Show detailed output |
@@ -353,12 +354,12 @@ npx vercel-seo-audit https://your-site.com --report md
 * [x] ~~Open Graph & Twitter Card image validation ([#36](https://github.com/JosephDoUrden/vercel-seo-audit/issues/36))~~
 * [x] ~~Security headers audit ([#37](https://github.com/JosephDoUrden/vercel-seo-audit/issues/37))~~
 * [x] ~~Performance hints (resource size, render-blocking) ([#38](https://github.com/JosephDoUrden/vercel-seo-audit/issues/38))~~
+* [x] ~~HTML report format with interactive dashboard ([#39](https://github.com/JosephDoUrden/vercel-seo-audit/issues/39))~~
 
 ### Up next
 
 * [ ] `--ignore` flag and `.seoauditignore` support ([#41](https://github.com/JosephDoUrden/vercel-seo-audit/issues/41)) `good first issue`
 * [ ] GitHub Actions PR comment integration ([#44](https://github.com/JosephDoUrden/vercel-seo-audit/issues/44)) `good first issue`
-* [ ] HTML report format with interactive dashboard ([#39](https://github.com/JosephDoUrden/vercel-seo-audit/issues/39))
 * [ ] `--fix` flag with auto-fix suggestions ([#40](https://github.com/JosephDoUrden/vercel-seo-audit/issues/40))
 * [ ] Internal broken link checker ([#42](https://github.com/JosephDoUrden/vercel-seo-audit/issues/42))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface SeoAuditConfig {
   verbose?: boolean;
   userAgent?: string;
   pages?: string[];
-  report?: string;
+  report?: 'json' | 'md' | 'html';
   timeout?: number;
 }
 

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -106,7 +106,7 @@ describe('validateConfig', () => {
   });
 
   it('throws when report is invalid', () => {
-    expect(() => validateConfig({ report: 'html' })).toThrow('"report" must be "json" or "md"');
+    expect(() => validateConfig({ report: 'pdf' })).toThrow('"report" must be "json", "md", or "html"');
   });
 
   it('throws when url is not a string', () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -81,8 +81,8 @@ export function validateConfig(raw: unknown): SeoAuditConfig {
   }
 
   if ('report' in obj) {
-    if (obj.report !== 'json' && obj.report !== 'md') {
-      throw new Error(`Error in ${CONFIG_FILE}: "report" must be "json" or "md"`);
+    if (obj.report !== 'json' && obj.report !== 'md' && obj.report !== 'html') {
+      throw new Error(`Error in ${CONFIG_FILE}: "report" must be "json", "md", or "html"`);
     }
     config.report = obj.report;
   }

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { formatHtml } from './output.js';
+import type { AuditReport } from '../types.js';
+
+function makeReport(overrides?: Partial<AuditReport>): AuditReport {
+  return {
+    url: 'https://example.com',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    duration: 500,
+    summary: { errors: 1, warnings: 1, info: 0, passed: 1 },
+    modules: [
+      {
+        module: 'metadata',
+        findings: [
+          {
+            code: 'TITLE_MISSING',
+            severity: 'error',
+            category: 'metadata',
+            message: 'Title tag is missing',
+            explanation: 'The page has no title tag.',
+            suggestion: 'Add a <title> tag.',
+          },
+          {
+            code: 'DESCRIPTION_MISSING',
+            severity: 'warning',
+            category: 'metadata',
+            message: 'Meta description is missing',
+            explanation: 'No meta description found.',
+            suggestion: 'Add a meta description.',
+          },
+          {
+            code: 'CHARSET_MISSING',
+            severity: 'pass',
+            category: 'metadata',
+            message: 'Charset present',
+            explanation: 'Charset is set.',
+            suggestion: 'No action needed.',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('formatHtml', () => {
+  it('returns valid HTML structure', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toContain('<html');
+    expect(html).toContain('</html>');
+    expect(html).toContain('<head>');
+    expect(html).toContain('</head>');
+    expect(html).toContain('<body>');
+    expect(html).toContain('</body>');
+  });
+
+  it('contains report URL and metadata', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toContain('https://example.com');
+    expect(html).toContain('2026-01-01T00:00:00.000Z');
+    expect(html).toContain('500ms');
+  });
+
+  it('contains summary counts', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toContain('Errors');
+    expect(html).toContain('Warnings');
+    expect(html).toContain('Passed');
+  });
+
+  it('contains category sections and finding messages', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toContain('Metadata');
+    expect(html).toContain('Title tag is missing');
+    expect(html).toContain('Meta description is missing');
+  });
+
+  it('contains filter controls', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toContain('filter-btn');
+    expect(html).toContain('data-filter="error"');
+    expect(html).toContain('data-filter="warning"');
+  });
+
+  it('contains style and script tags', () => {
+    const html = formatHtml(makeReport());
+    expect(html).toContain('<style>');
+    expect(html).toContain('<script>');
+  });
+
+  it('shows no issues message for empty findings', () => {
+    const html = formatHtml(makeReport({
+      summary: { errors: 0, warnings: 0, info: 0, passed: 0 },
+      modules: [],
+    }));
+    expect(html).toContain('No issues found!');
+  });
+
+  it('escapes HTML in URLs and messages', () => {
+    const html = formatHtml(makeReport({
+      url: 'https://example.com/<script>',
+      modules: [{
+        module: 'test',
+        findings: [{
+          code: 'TITLE_MISSING',
+          severity: 'error',
+          category: 'metadata',
+          message: 'Test <b>bold</b>',
+          explanation: 'Explanation',
+          suggestion: 'Fix it',
+        }],
+      }],
+    }));
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;b&gt;bold&lt;/b&gt;');
+    expect(html).not.toContain('<script>alert');
+  });
+
+  it('includes finding URL when present', () => {
+    const html = formatHtml(makeReport({
+      modules: [{
+        module: 'test',
+        findings: [{
+          code: 'TITLE_MISSING',
+          severity: 'error',
+          category: 'metadata',
+          message: 'Issue',
+          explanation: 'Explain',
+          suggestion: 'Fix',
+          url: 'https://example.com/page',
+        }],
+      }],
+    }));
+    expect(html).toContain('https://example.com/page');
+  });
+});

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -152,6 +152,143 @@ export function formatMarkdown(report: AuditReport): string {
   return lines.join('\n');
 }
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function formatHtml(report: AuditReport): string {
+  const { errors, warnings, info, passed } = report.summary;
+
+  const allFindings: AuditFinding[] = report.modules.flatMap((m) => m.findings);
+  const categories = new Map<string, AuditFinding[]>();
+  for (const finding of allFindings) {
+    const cat = finding.category;
+    if (!categories.has(cat)) categories.set(cat, []);
+    categories.get(cat)!.push(finding);
+  }
+
+  const severityHtmlIcons: Record<string, string> = {
+    error: '&#10006;',
+    warning: '&#9888;',
+    info: '&#8505;',
+    pass: '&#10004;',
+  };
+
+  let findingsHtml = '';
+  if (allFindings.length === 0) {
+    findingsHtml = '<p class="no-issues">No issues found!</p>';
+  } else {
+    for (const [category, findings] of categories) {
+      const label = escapeHtml(category.charAt(0).toUpperCase() + category.slice(1));
+      const items = findings
+        .map((f) => {
+          const icon = severityHtmlIcons[f.severity] ?? '';
+          let html = `<div class="finding" data-severity="${f.severity}">`;
+          html += `<span class="finding-icon severity-${f.severity}">${icon}</span>`;
+          html += `<div class="finding-content">`;
+          html += `<strong>[${escapeHtml(f.severity.toUpperCase())}]</strong> ${escapeHtml(f.message)}`;
+          html += `<div class="finding-explanation">${escapeHtml(f.explanation)}</div>`;
+          html += `<div class="finding-suggestion">&rarr; ${escapeHtml(f.suggestion)}</div>`;
+          if (f.url) {
+            html += `<div class="finding-url">URL: ${escapeHtml(f.url)}</div>`;
+          }
+          html += `</div></div>`;
+          return html;
+        })
+        .join('\n');
+      findingsHtml += `<details class="category" open><summary>${label}</summary>${items}</details>`;
+    }
+  }
+
+  const summaryCards = [
+    { label: 'Errors', count: errors, cls: 'error' },
+    { label: 'Warnings', count: warnings, cls: 'warning' },
+    { label: 'Info', count: info, cls: 'info' },
+    { label: 'Passed', count: passed, cls: 'pass' },
+  ]
+    .map((c) => `<div class="card severity-${c.cls}"><div class="card-count">${c.count}</div><div class="card-label">${c.label}</div></div>`)
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SEO Audit Report — ${escapeHtml(report.url)}</title>
+<style>
+*,*::before,*::after{box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin:0;padding:0;background:#f5f7fa;color:#1a1a2e}
+.container{max-width:900px;margin:0 auto;padding:24px}
+header{margin-bottom:32px}
+h1{font-size:1.5rem;margin:0 0 8px}
+.meta{color:#6b7280;font-size:.875rem}
+.summary{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:32px}
+.card{flex:1;min-width:120px;padding:16px;border-radius:8px;text-align:center;background:#fff;border:1px solid #e5e7eb}
+.card-count{font-size:2rem;font-weight:700}
+.card-label{font-size:.875rem;color:#6b7280;margin-top:4px}
+.card.severity-error .card-count{color:#dc2626}
+.card.severity-warning .card-count{color:#d97706}
+.card.severity-info .card-count{color:#2563eb}
+.card.severity-pass .card-count{color:#16a34a}
+.filters{margin-bottom:24px;display:flex;gap:8px;flex-wrap:wrap}
+.filter-btn{padding:6px 14px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;font-size:.875rem}
+.filter-btn.active{background:#1a1a2e;color:#fff;border-color:#1a1a2e}
+.category{margin-bottom:16px;background:#fff;border-radius:8px;border:1px solid #e5e7eb;overflow:hidden}
+.category summary{padding:12px 16px;font-weight:600;cursor:pointer;background:#fafafa;font-size:1rem}
+.finding{display:flex;gap:12px;padding:12px 16px;border-top:1px solid #f0f0f0}
+.finding-icon{font-size:1.1rem;flex-shrink:0;width:24px;text-align:center}
+.severity-error{color:#dc2626}
+.severity-warning{color:#d97706}
+.severity-info{color:#2563eb}
+.severity-pass{color:#16a34a}
+.finding-content{flex:1;font-size:.9rem;line-height:1.5}
+.finding-explanation{color:#6b7280;margin-top:2px}
+.finding-suggestion{color:#0369a1;margin-top:2px}
+.finding-url{color:#6b7280;font-size:.8rem;margin-top:2px}
+.no-issues{text-align:center;color:#16a34a;font-size:1.1rem;padding:32px}
+.finding.hidden{display:none}
+</style>
+</head>
+<body>
+<div class="container">
+<header>
+<h1>SEO Audit Report</h1>
+<div class="meta">URL: ${escapeHtml(report.url)} &mdash; ${escapeHtml(report.timestamp)} &mdash; ${report.duration}ms</div>
+</header>
+<section class="summary">${summaryCards}</section>
+<div class="filters">
+<button class="filter-btn active" data-filter="all">All</button>
+<button class="filter-btn" data-filter="error">Errors</button>
+<button class="filter-btn" data-filter="warning">Warnings</button>
+<button class="filter-btn" data-filter="info">Info</button>
+<button class="filter-btn" data-filter="pass">Passed</button>
+</div>
+<section class="findings">${findingsHtml}</section>
+</div>
+<script>
+document.querySelectorAll('.filter-btn').forEach(function(btn){
+  btn.addEventListener('click',function(){
+    document.querySelectorAll('.filter-btn').forEach(function(b){b.classList.remove('active')});
+    btn.classList.add('active');
+    var filter=btn.getAttribute('data-filter');
+    document.querySelectorAll('.finding').forEach(function(el){
+      if(filter==='all'||el.getAttribute('data-severity')===filter){
+        el.classList.remove('hidden');
+      }else{
+        el.classList.add('hidden');
+      }
+    });
+  });
+});
+</script>
+</body>
+</html>`;
+}
+
 export function formatDiff(diff: DiffResult): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary
- Add `--report html` option to generate a self-contained HTML report with an interactive dashboard
- Report includes severity-colored summary cards, collapsible category sections, and client-side severity filter buttons
- No external dependencies — all CSS and JS are embedded inline

Closes #39

## Changes
- **`src/types.ts`** — Narrowed `report` type to `'json' | 'md' | 'html'`
- **`src/utils/output.ts`** — Added `formatHtml()` with responsive design, `<details>` grouping, and filter `<script>`
- **`src/utils/output.test.ts`** — 9 tests covering HTML structure, escaping, empty state, and filter controls
- **`src/cli.ts`** — Accept `html` in `--report` flag and write `report.html`
- **`src/utils/config.ts`** / **`config.test.ts`** — Accept `html` in config validation
- **`README.md`** — Updated docs and moved #39 to completed in roadmap

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 338 tests pass (including 9 new)
- [x] `node bin/vercel-seo-audit.js https://example.com --report html` generates valid `report.html`
- [ ] Open `report.html` in browser — verify layout, summary cards, collapsible sections, and filter buttons