### PR TITLE
feat: add landing page for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,34 @@
+name: Deploy Landing Page
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,9 @@
       "extra-files": [
         "src/cli.ts",
         "src/constants.ts"
+      ],
+      "exclude-paths": [
+        "site"
       ]
     }
   }

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#2563eb"/>
+  <text x="32" y="38" font-family="monospace" font-size="22" font-weight="700" fill="#fff" text-anchor="middle">&lt;/&gt;</text>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,850 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>vercel-seo-audit — CLI that diagnoses SEO issues for Next.js &amp; Vercel</title>
+<meta name="description" content="A fast, developer-friendly CLI that explains why Google isn't indexing your Next.js site. Detects redirect traps, missing robots/sitemap, noindex headers, canonical mismatches, and Vercel quirks.">
+<meta name="theme-color" content="#0a0a0a">
+<link rel="canonical" href="https://josephdourden.github.io/vercel-seo-audit/">
+<link rel="icon" type="image/svg+xml" href="./favicon.svg">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:title" content="vercel-seo-audit — CLI for Next.js SEO issues">
+<meta property="og:description" content="A fast CLI that explains why Google isn't indexing your Next.js site. Redirect traps, missing robots/sitemap, canonical mismatches, and Vercel quirks.">
+<meta property="og:url" content="https://josephdourden.github.io/vercel-seo-audit/">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="vercel-seo-audit — CLI for Next.js SEO issues">
+<meta name="twitter:description" content="A fast CLI that explains why Google isn't indexing your Next.js site.">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "vercel-seo-audit",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Any",
+  "description": "CLI tool that diagnoses SEO and indexing issues for Next.js/Vercel websites",
+  "url": "https://github.com/JosephDoUrden/vercel-seo-audit",
+  "license": "https://opensource.org/licenses/MIT",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<!-- Fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+/* ── Reset & Base ──────────────────────────────────── */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth;scroll-padding-top:80px}
+@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
+
+/* ── Theme tokens ──────────────────────────────────── */
+:root{
+  --font-sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --font-mono:"JetBrains Mono",ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  --max-w:1120px;
+  --nav-h:64px;
+  --radius:10px;
+  --radius-sm:6px;
+  --transition:150ms ease;
+}
+
+[data-theme="dark"]{
+  --bg:        #0a0a0a;
+  --bg-subtle: #141414;
+  --bg-card:   #1a1a1a;
+  --bg-code:   #111111;
+  --border:    #262626;
+  --border-subtle:#1f1f1f;
+  --text:      #fafafa;
+  --text-muted:#a1a1aa;
+  --text-dim:  #71717a;
+  --accent:    #2563eb;
+  --accent-hover:#3b82f6;
+  --error:     #dc2626;
+  --warning:   #d97706;
+  --info:      #2563eb;
+  --pass:      #16a34a;
+  --suggestion:#06b6d4;
+  --nav-bg:    rgba(10,10,10,.8);
+  --code-bg:   #0d0d0d;
+  --terminal-bg:#0d0d0d;
+  --badge-bg:  #1a1a1a;
+}
+
+[data-theme="light"]{
+  --bg:        #ffffff;
+  --bg-subtle: #f9fafb;
+  --bg-card:   #ffffff;
+  --bg-code:   #f3f4f6;
+  --border:    #e5e7eb;
+  --border-subtle:#f0f0f0;
+  --text:      #111827;
+  --text-muted:#6b7280;
+  --text-dim:  #9ca3af;
+  --accent:    #2563eb;
+  --accent-hover:#1d4ed8;
+  --error:     #dc2626;
+  --warning:   #d97706;
+  --info:      #2563eb;
+  --pass:      #16a34a;
+  --suggestion:#0891b2;
+  --nav-bg:    rgba(255,255,255,.8);
+  --code-bg:   #f3f4f6;
+  --terminal-bg:#1e1e1e;
+  --badge-bg:  #f3f4f6;
+}
+
+body{
+  font-family:var(--font-sans);
+  background:var(--bg);
+  color:var(--text);
+  line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+  overflow-x:hidden;
+}
+
+a{color:var(--accent);text-decoration:none;transition:color var(--transition)}
+a:hover{color:var(--accent-hover)}
+
+/* ── Container ────────────────────────────────────── */
+.container{max-width:var(--max-w);margin:0 auto;padding:0 24px}
+
+/* ── Navigation ───────────────────────────────────── */
+.nav{
+  position:sticky;top:0;z-index:100;
+  background:var(--nav-bg);
+  backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--border);
+  height:var(--nav-h);
+}
+.nav .container{
+  display:flex;align-items:center;justify-content:space-between;
+  height:100%;
+}
+.nav-logo{
+  font-weight:700;font-size:1.05rem;color:var(--text);
+  font-family:var(--font-mono);
+  display:flex;align-items:center;gap:8px;
+}
+.nav-logo svg{width:24px;height:24px}
+.nav-links{display:flex;align-items:center;gap:28px;list-style:none}
+.nav-links a{color:var(--text-muted);font-size:.875rem;font-weight:500;transition:color var(--transition)}
+.nav-links a:hover,.nav-links a.active{color:var(--text)}
+.nav-right{display:flex;align-items:center;gap:12px}
+
+/* Theme toggle */
+.theme-toggle{
+  background:none;border:none;cursor:pointer;
+  color:var(--text-muted);padding:8px;border-radius:var(--radius-sm);
+  display:flex;align-items:center;justify-content:center;
+  transition:color var(--transition),background var(--transition);
+}
+.theme-toggle:hover{color:var(--text);background:var(--bg-card)}
+.theme-toggle svg{width:18px;height:18px}
+[data-theme="dark"] .icon-sun{display:none}
+[data-theme="light"] .icon-moon{display:none}
+
+/* Hamburger */
+.hamburger{
+  display:none;background:none;border:none;cursor:pointer;
+  color:var(--text-muted);padding:8px;border-radius:var(--radius-sm);
+}
+.hamburger svg{width:22px;height:22px}
+
+/* Mobile nav */
+.mobile-nav{
+  display:none;position:fixed;top:var(--nav-h);left:0;right:0;bottom:0;
+  background:var(--bg);z-index:99;
+  padding:24px;
+}
+.mobile-nav.open{display:flex;flex-direction:column;gap:4px}
+.mobile-nav a{
+  display:block;padding:14px 16px;border-radius:var(--radius-sm);
+  color:var(--text);font-size:1rem;font-weight:500;
+  transition:background var(--transition);
+}
+.mobile-nav a:hover{background:var(--bg-card)}
+
+@media(max-width:768px){
+  .nav-links{display:none}
+  .hamburger{display:flex;align-items:center;justify-content:center}
+}
+
+/* ── Section base ─────────────────────────────────── */
+section{padding:80px 0}
+@media(max-width:640px){section{padding:56px 0}}
+
+.section-label{
+  font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;
+  color:var(--accent);margin-bottom:8px;
+}
+.section-title{font-size:1.75rem;font-weight:700;margin-bottom:12px;line-height:1.3}
+.section-desc{color:var(--text-muted);max-width:600px;margin-bottom:40px}
+@media(max-width:640px){
+  .section-title{font-size:1.4rem}
+}
+
+/* ── Hero ─────────────────────────────────────────── */
+.hero{padding:100px 0 80px;text-align:center}
+@media(max-width:640px){.hero{padding:72px 0 56px}}
+.hero-title{
+  font-size:2.75rem;font-weight:700;line-height:1.2;
+  max-width:720px;margin:0 auto 20px;
+  background:linear-gradient(135deg,var(--text) 0%,var(--text-muted) 100%);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  background-clip:text;
+}
+@media(max-width:640px){.hero-title{font-size:1.75rem}}
+.hero-sub{
+  font-size:1.1rem;color:var(--text-muted);
+  max-width:600px;margin:0 auto 32px;line-height:1.7;
+}
+@media(max-width:640px){.hero-sub{font-size:1rem}}
+
+/* Code block (hero + quick-start) */
+.code-block{
+  position:relative;display:inline-flex;align-items:center;
+  background:var(--code-bg);border:1px solid var(--border);
+  border-radius:var(--radius);padding:14px 52px 14px 20px;
+  font-family:var(--font-mono);font-size:.95rem;color:var(--text);
+  max-width:100%;overflow-x:auto;
+}
+.code-block .prompt{color:var(--accent);margin-right:8px;user-select:none}
+
+/* Copy button */
+.copy-btn{
+  position:absolute;right:8px;top:50%;transform:translateY(-50%);
+  background:none;border:none;cursor:pointer;
+  color:var(--text-dim);padding:8px;border-radius:var(--radius-sm);
+  display:flex;align-items:center;justify-content:center;
+  transition:color var(--transition),background var(--transition);
+}
+.copy-btn:hover{color:var(--text);background:var(--bg-subtle)}
+.copy-btn svg{width:16px;height:16px}
+.copy-btn.copied{color:var(--pass)}
+
+/* Badges */
+.badges{display:flex;justify-content:center;gap:8px;flex-wrap:wrap;margin-top:24px}
+.badges img{height:20px}
+
+/* ── Features ─────────────────────────────────────── */
+.features-grid{
+  display:grid;grid-template-columns:repeat(2,1fr);gap:20px;
+}
+@media(max-width:640px){.features-grid{grid-template-columns:1fr}}
+.feature-card{
+  background:var(--bg-card);border:1px solid var(--border);
+  border-radius:var(--radius);padding:28px;
+  transition:border-color var(--transition),box-shadow var(--transition);
+}
+.feature-card:hover{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent)}
+.feature-icon{
+  width:40px;height:40px;border-radius:var(--radius-sm);
+  background:var(--bg-subtle);border:1px solid var(--border);
+  display:flex;align-items:center;justify-content:center;
+  margin-bottom:16px;color:var(--accent);
+}
+.feature-icon svg{width:20px;height:20px}
+.feature-card h3{font-size:1rem;font-weight:600;margin-bottom:6px}
+.feature-card p{color:var(--text-muted);font-size:.9rem;line-height:1.6}
+
+/* ── Checks grid ──────────────────────────────────── */
+.checks-grid{
+  display:grid;grid-template-columns:repeat(4,1fr);gap:16px;
+}
+@media(max-width:1024px){.checks-grid{grid-template-columns:repeat(3,1fr)}}
+@media(max-width:640px){.checks-grid{grid-template-columns:repeat(2,1fr)}}
+.check-item{
+  background:var(--bg-card);border:1px solid var(--border);
+  border-radius:var(--radius);padding:20px;text-align:center;
+  transition:border-color var(--transition);
+}
+.check-item:hover{border-color:var(--text-dim)}
+.check-icon{
+  width:36px;height:36px;margin:0 auto 12px;
+  color:var(--accent);display:flex;align-items:center;justify-content:center;
+}
+.check-icon svg{width:24px;height:24px}
+.check-item h4{font-size:.875rem;font-weight:600;margin-bottom:4px}
+.check-item p{color:var(--text-muted);font-size:.78rem;line-height:1.5}
+
+/* ── Terminal output ──────────────────────────────── */
+.terminal{
+  background:var(--terminal-bg);border:1px solid var(--border);
+  border-radius:var(--radius);overflow:hidden;max-width:720px;
+  margin:0 auto;
+}
+.terminal-bar{
+  display:flex;align-items:center;gap:8px;padding:12px 16px;
+  background:rgba(255,255,255,.04);border-bottom:1px solid var(--border);
+}
+.terminal-dot{width:12px;height:12px;border-radius:50%}
+.terminal-dot.red{background:#ff5f57}
+.terminal-dot.yellow{background:#febc2e}
+.terminal-dot.green{background:#28c840}
+.terminal-title{
+  flex:1;text-align:center;font-size:.75rem;
+  color:var(--text-dim);font-family:var(--font-mono);
+}
+.terminal-body{
+  position:relative;padding:20px;font-family:var(--font-mono);
+  font-size:.82rem;line-height:1.8;color:#d4d4d8;
+  overflow-x:auto;white-space:pre;
+}
+.terminal-body .copy-btn{top:12px;right:12px;transform:none;color:#71717a}
+.terminal-body .copy-btn:hover{color:#d4d4d8;background:rgba(255,255,255,.08)}
+.t-error{color:#f87171}
+.t-warning{color:#fbbf24}
+.t-pass{color:#4ade80}
+.t-info{color:#60a5fa}
+.t-suggestion{color:#22d3ee}
+.t-dim{color:#71717a}
+.t-heading{color:#e4e4e7;font-weight:600}
+.t-line{color:#3f3f46}
+
+/* ── Quick start ──────────────────────────────────── */
+.qs-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}
+@media(max-width:768px){.qs-grid{grid-template-columns:1fr}}
+.qs-panel{
+  background:var(--bg-card);border:1px solid var(--border);
+  border-radius:var(--radius);overflow:hidden;
+}
+.qs-panel-header{
+  padding:12px 16px;font-size:.8rem;font-weight:600;
+  color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;
+  background:var(--bg-subtle);border-bottom:1px solid var(--border);
+}
+.qs-panel-body{padding:20px}
+.qs-panel-body pre{
+  background:var(--code-bg);border:1px solid var(--border);
+  border-radius:var(--radius-sm);padding:16px;
+  font-family:var(--font-mono);font-size:.82rem;line-height:1.7;
+  color:var(--text);overflow-x:auto;position:relative;
+}
+.qs-panel-body pre .copy-btn{top:8px;right:8px;transform:none}
+
+/* Flags table */
+.flags-table{width:100%;border-collapse:collapse;font-size:.85rem}
+.flags-table th{
+  text-align:left;padding:10px 12px;font-weight:600;font-size:.78rem;
+  text-transform:uppercase;letter-spacing:.04em;color:var(--text-muted);
+  border-bottom:1px solid var(--border);
+}
+.flags-table td{padding:10px 12px;border-bottom:1px solid var(--border-subtle)}
+.flags-table code{
+  font-family:var(--font-mono);font-size:.8rem;
+  background:var(--code-bg);padding:2px 6px;border-radius:4px;
+}
+
+/* ── Footer / CTA ─────────────────────────────────── */
+.cta{
+  text-align:center;padding:80px 0;
+  border-top:1px solid var(--border);
+}
+.cta-title{font-size:1.75rem;font-weight:700;margin-bottom:8px}
+@media(max-width:640px){.cta-title{font-size:1.35rem}}
+.cta-sub{color:var(--text-muted);margin-bottom:32px}
+.cta .code-block{margin-bottom:28px}
+.cta-contribute{color:var(--text-muted);font-size:.95rem;margin-bottom:16px}
+.contribute-btn{
+  display:inline-flex;align-items:center;gap:8px;
+  padding:12px 28px;border-radius:var(--radius);
+  background:var(--text);color:var(--bg);
+  font-weight:600;font-size:.95rem;
+  transition:opacity var(--transition);
+  margin-bottom:40px;
+}
+.contribute-btn:hover{opacity:.85;color:var(--bg)}
+.contribute-btn svg{width:20px;height:20px}
+
+.footer-links{
+  display:flex;justify-content:center;gap:24px;
+  flex-wrap:wrap;margin-bottom:16px;
+}
+.footer-links a{color:var(--text-muted);font-size:.875rem;font-weight:500}
+.footer-links a:hover{color:var(--text)}
+.copyright{color:var(--text-dim);font-size:.8rem}
+</style>
+</head>
+<body>
+
+<!-- ═══ Navigation ═══════════════════════════════════ -->
+<nav class="nav" id="nav">
+  <div class="container">
+    <a href="#" class="nav-logo">
+      <svg viewBox="0 0 64 64" fill="none"><circle cx="32" cy="32" r="30" fill="#2563eb"/><text x="32" y="38" font-family="monospace" font-size="22" font-weight="700" fill="#fff" text-anchor="middle">&lt;/&gt;</text></svg>
+      vercel-seo-audit
+    </a>
+    <ul class="nav-links">
+      <li><a href="#features">Features</a></li>
+      <li><a href="#checks">Checks</a></li>
+      <li><a href="#output">Output</a></li>
+      <li><a href="#quickstart">Quick Start</a></li>
+    </ul>
+    <div class="nav-right">
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+      <button class="hamburger" id="hamburger" aria-label="Open menu">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+    </div>
+  </div>
+</nav>
+
+<!-- Mobile nav -->
+<div class="mobile-nav" id="mobileNav">
+  <a href="#features">Features</a>
+  <a href="#checks">Checks</a>
+  <a href="#output">Output</a>
+  <a href="#quickstart">Quick Start</a>
+  <a href="https://github.com/JosephDoUrden/vercel-seo-audit" target="_blank" rel="noopener">GitHub</a>
+</div>
+
+<!-- ═══ Hero ═════════════════════════════════════════ -->
+<section class="hero" id="hero">
+  <div class="container">
+    <h1 class="hero-title">If you're using Vercel and Google hates your site, this is for you.</h1>
+    <p class="hero-sub">A fast, developer-friendly CLI that explains <strong>why Google isn't indexing your Next.js site</strong> &mdash; beyond the vague stuff in Search Console.</p>
+    <div class="code-block" id="heroCode">
+      <span class="prompt">$</span> npm i -g vercel-seo-audit
+      <button class="copy-btn" data-copy="npm i -g vercel-seo-audit" aria-label="Copy command">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      </button>
+    </div>
+    <div class="badges">
+      <a href="https://www.npmjs.com/package/vercel-seo-audit"><img src="https://img.shields.io/npm/v/vercel-seo-audit.svg" alt="npm version"></a>
+      <a href="https://www.npmjs.com/package/vercel-seo-audit"><img src="https://img.shields.io/npm/dm/vercel-seo-audit.svg" alt="npm downloads"></a>
+      <a href="https://github.com/JosephDoUrden/vercel-seo-audit/actions/workflows/ci.yml"><img src="https://github.com/JosephDoUrden/vercel-seo-audit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+      <a href="https://github.com/JosephDoUrden/vercel-seo-audit/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/vercel-seo-audit.svg" alt="license"></a>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ Features ═════════════════════════════════════ -->
+<section id="features">
+  <div class="container">
+    <p class="section-label">Features</p>
+    <h2 class="section-title">Everything you need, nothing you don't</h2>
+    <p class="section-desc">One command. Zero config. Real answers about why your pages aren't showing up in Google.</p>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        </div>
+        <h3>Fast CLI</h3>
+        <p>Two-phase parallel execution delivers results in seconds. Audit your homepage, robots, sitemap, and sampled pages all at once.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48 2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48 2.83-2.83"/></svg>
+        </div>
+        <h3>Zero Config</h3>
+        <p>Works instantly with npx. Optionally add a <code>.seoauditrc.json</code> to set project-level defaults for your team.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        </div>
+        <h3>CI-Ready</h3>
+        <p>Built-in GitHub Action. Use <code>--strict</code> to fail pipelines on warnings. Export JSON or Markdown reports for PR comments.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+        </div>
+        <h3>HTML Reports</h3>
+        <p>Generate interactive dashboards with <code>--report&nbsp;html</code>. Filter by severity, expand categories, and share with your team.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ Checks ═══════════════════════════════════════ -->
+<section id="checks">
+  <div class="container">
+    <p class="section-label">What it checks</p>
+    <h2 class="section-title">12 audit categories, one command</h2>
+    <p class="section-desc">Covers the misconfigs that silently kill crawling and indexing on Next.js and Vercel sites.</p>
+    <div class="checks-grid">
+      <!-- Redirects -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 10 20 15 15 20"/><path d="M4 4v7a4 4 0 0 0 4 4h12"/></svg>
+        </div>
+        <h4>Redirects</h4>
+        <p>Chains, loops, trailing-slash traps, HTTP&rarr;HTTPS</p>
+      </div>
+      <!-- Robots -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="4" y="8" width="16" height="12" rx="2"/><circle cx="9" cy="14" r="1"/><circle cx="15" cy="14" r="1"/></svg>
+        </div>
+        <h4>Robots.txt</h4>
+        <p>Missing file, Disallow rules, Googlebot blocks</p>
+      </div>
+      <!-- Sitemap -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        </div>
+        <h4>Sitemap</h4>
+        <p>Missing, malformed, empty, redirect issues</p>
+      </div>
+      <!-- Metadata -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h16v3"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>
+        </div>
+        <h4>Metadata</h4>
+        <p>Canonical, noindex, title, OG tags, Twitter Cards</p>
+      </div>
+      <!-- Favicon -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+        </div>
+        <h4>Favicon</h4>
+        <p>Missing icons, conflicting declarations</p>
+      </div>
+      <!-- Next.js -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/><line x1="12" y1="22" x2="12" y2="15.5"/><polyline points="22 8.5 12 15.5 2 8.5"/></svg>
+        </div>
+        <h4>Next.js / Vercel</h4>
+        <p>308 traps, middleware rewrites, deploy detection</p>
+      </div>
+      <!-- Structured Data -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+        </div>
+        <h4>Structured Data</h4>
+        <p>JSON-LD validation, required fields, schema types</p>
+      </div>
+      <!-- Crawl -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </div>
+        <h4>Crawl Mode</h4>
+        <p>Audit every sitemap URL for SEO issues</p>
+      </div>
+      <!-- i18n -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        </div>
+        <h4>i18n / hreflang</h4>
+        <p>Language codes, self-ref, x-default, reciprocal links</p>
+      </div>
+      <!-- Images -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+        </div>
+        <h4>Images</h4>
+        <p>Missing alt, lazy loading, next/image, oversized</p>
+      </div>
+      <!-- Security -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        </div>
+        <h4>Security Headers</h4>
+        <p>HSTS, X-Content-Type, frame protection, referrer</p>
+      </div>
+      <!-- Performance -->
+      <div class="check-item">
+        <div class="check-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+        </div>
+        <h4>Performance</h4>
+        <p>Document size, render-blocking scripts, preconnect</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ Example Output ═══════════════════════════════ -->
+<section id="output">
+  <div class="container">
+    <p class="section-label">Example output</p>
+    <h2 class="section-title">Clear, actionable results</h2>
+    <p class="section-desc">Every finding tells you exactly what's wrong and how to fix it. No vague scores.</p>
+    <div class="terminal">
+      <div class="terminal-bar">
+        <span class="terminal-dot red"></span>
+        <span class="terminal-dot yellow"></span>
+        <span class="terminal-dot green"></span>
+        <span class="terminal-title">vercel-seo-audit</span>
+      </div>
+      <div class="terminal-body" id="terminalBody"><button class="copy-btn" data-copy-terminal aria-label="Copy output"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button><span class="t-heading">SEO Audit Report for https://example.com/</span>
+<span class="t-dim">  Completed in 1118ms at 2026-01-31T12:30:54.448Z</span>
+
+  Summary:
+    <span class="t-error">&#10006; 1 error</span>
+    <span class="t-warning">&#9888; 3 warnings</span>
+    <span class="t-info">&#8505; 2 info</span>
+    <span class="t-pass">&#10004; 4 passed</span>
+
+  <span class="t-heading">REDIRECTS</span>
+  <span class="t-line">&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
+  <span class="t-error">&#10006; [ERROR] Redirect chain detected (3 hops)</span>
+    <span class="t-suggestion">&#8594; Reduce to a single redirect: http://example.com &#8594; https://example.com/</span>
+
+  <span class="t-heading">ROBOTS</span>
+  <span class="t-line">&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
+  <span class="t-warning">&#9888; [WARNING] robots.txt not found</span>
+    <span class="t-suggestion">&#8594; Create a robots.txt at /robots.txt</span>
+
+  <span class="t-heading">SITEMAP</span>
+  <span class="t-line">&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
+  <span class="t-warning">&#9888; [WARNING] sitemap.xml not found</span>
+    <span class="t-suggestion">&#8594; Add app/sitemap.ts in Next.js App Router</span>
+
+  <span class="t-heading">METADATA</span>
+  <span class="t-line">&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
+  <span class="t-warning">&#9888; [WARNING] Canonical URL mismatch</span>
+    <span class="t-suggestion">&#8594; Canonical points to https://www.example.com/ but page is https://example.com/</span>
+  <span class="t-pass">&#10004; [PASS] Title tag present</span>
+  <span class="t-pass">&#10004; [PASS] Meta description present</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ Quick Start ══════════════════════════════════ -->
+<section id="quickstart">
+  <div class="container">
+    <p class="section-label">Quick start</p>
+    <h2 class="section-title">Up and running in seconds</h2>
+    <p class="section-desc">Install globally via npm and start auditing in seconds.</p>
+
+    <div class="qs-grid">
+      <!-- Install -->
+      <div class="qs-panel">
+        <div class="qs-panel-header">Install</div>
+        <div class="qs-panel-body">
+          <pre><button class="copy-btn" data-copy="npm i -g vercel-seo-audit" aria-label="Copy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button><code><span class="t-dim"># Install globally</span>
+npm i -g vercel-seo-audit
+vercel-seo-audit https://your-site.com
+
+<span class="t-dim"># Or run once with npx</span>
+npx vercel-seo-audit https://your-site.com</code></pre>
+        </div>
+      </div>
+
+      <!-- Config file -->
+      <div class="qs-panel">
+        <div class="qs-panel-header">Config file</div>
+        <div class="qs-panel-body">
+          <pre><button class="copy-btn" data-copy='{ "url": "https://your-site.com", "strict": true, "verbose": false, "userAgent": "googlebot", "pages": ["/docs", "/team", "/careers"], "report": "json", "timeout": 15000 }' aria-label="Copy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button><code><span class="t-dim">// .seoauditrc.json</span>
+{
+  "url": "https://your-site.com",
+  "strict": true,
+  "verbose": false,
+  "userAgent": "googlebot",
+  "pages": ["/docs", "/team", "/careers"],
+  "report": "json",
+  "timeout": 15000
+}</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <!-- Flags table -->
+    <div class="qs-panel" style="margin-top:24px">
+      <div class="qs-panel-header">CLI flags</div>
+      <div class="qs-panel-body" style="padding:0;overflow-x:auto">
+        <table class="flags-table">
+          <thead>
+            <tr><th>Flag</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>--strict</code></td><td>Fail on warnings too (exit code 1)</td></tr>
+            <tr><td><code>--report html</code></td><td>Generate interactive HTML dashboard</td></tr>
+            <tr><td><code>--crawl</code></td><td>Audit all sitemap URLs (default: 50 pages)</td></tr>
+            <tr><td><code>--diff &lt;file&gt;</code></td><td>Compare against a previous report to detect regressions</td></tr>
+            <tr><td><code>--json</code></td><td>Output results as JSON</td></tr>
+            <tr><td><code>--pages &lt;paths&gt;</code></td><td>Comma-separated page paths to audit</td></tr>
+            <tr><td><code>--user-agent &lt;ua&gt;</code></td><td>Audit as <code>googlebot</code>, <code>bingbot</code>, or custom string</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- GitHub Action -->
+    <div class="qs-panel" style="margin-top:24px">
+      <div class="qs-panel-header">GitHub Action</div>
+      <div class="qs-panel-body">
+        <pre><button class="copy-btn" data-copy-pre aria-label="Copy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button><code>name: SEO Audit
+on:
+  push:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JosephDoUrden/vercel-seo-audit@v1
+        with:
+          url: https://your-site.com
+          strict: true
+          report: json</code></pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ Footer / CTA ═════════════════════════════════ -->
+<footer class="cta">
+  <div class="container">
+    <h2 class="cta-title">Start auditing your site</h2>
+    <p class="cta-sub">Install from npm and find out why Google isn't indexing your pages.</p>
+    <div class="code-block">
+      <span class="prompt">$</span> npm i -g vercel-seo-audit
+      <button class="copy-btn" data-copy="npm i -g vercel-seo-audit" aria-label="Copy command">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      </button>
+    </div>
+    <p class="cta-contribute">Open source &amp; community-driven. We'd love your help.</p>
+    <a href="https://github.com/JosephDoUrden/vercel-seo-audit" target="_blank" rel="noopener" class="contribute-btn">
+      <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1.1-.8.1-.7.1-.7 1.2.1 1.9 1.3 1.9 1.3 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.3-3.2-.1-.3-.6-1.5.1-3.2 0 0 1-.3 3.4 1.2a11.5 11.5 0 0 1 6.2 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.7.2 2.9.1 3.2.8.8 1.3 1.9 1.3 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>
+      Contribute on GitHub
+    </a>
+    <div class="footer-links">
+      <a href="https://github.com/JosephDoUrden/vercel-seo-audit" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.npmjs.com/package/vercel-seo-audit" target="_blank" rel="noopener">npm</a>
+      <a href="https://github.com/JosephDoUrden/vercel-seo-audit/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+    </div>
+    <p class="copyright">&copy; 2026 vercel-seo-audit</p>
+  </div>
+</footer>
+
+<script>
+/* ── Theme toggle ─────────────────────────────────── */
+(function(){
+  var html = document.documentElement;
+  var toggle = document.getElementById('themeToggle');
+
+  function getPreferred(){
+    var stored = localStorage.getItem('theme');
+    if(stored) return stored;
+    return window.matchMedia('(prefers-color-scheme:light)').matches ? 'light' : 'dark';
+  }
+
+  html.setAttribute('data-theme', getPreferred());
+
+  toggle.addEventListener('click', function(){
+    var next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+})();
+
+/* ── Copy to clipboard ────────────────────────────── */
+document.addEventListener('click', function(e){
+  var btn = e.target.closest('.copy-btn');
+  if(!btn) return;
+
+  var text;
+  if(btn.hasAttribute('data-copy')){
+    text = btn.getAttribute('data-copy');
+  } else if(btn.hasAttribute('data-copy-terminal')){
+    text = document.getElementById('terminalBody').textContent.trim();
+  } else if(btn.hasAttribute('data-copy-pre')){
+    var pre = btn.closest('pre');
+    if(pre){
+      var code = pre.querySelector('code');
+      text = (code || pre).textContent.trim();
+    }
+  }
+
+  if(!text) return;
+
+  if(navigator.clipboard && navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text);
+  } else {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+  }
+
+  btn.classList.add('copied');
+  var svg = btn.innerHTML;
+  btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+  setTimeout(function(){
+    btn.innerHTML = svg;
+    btn.classList.remove('copied');
+  }, 1500);
+});
+
+/* ── Mobile nav ───────────────────────────────────── */
+(function(){
+  var hamburger = document.getElementById('hamburger');
+  var mobileNav = document.getElementById('mobileNav');
+
+  hamburger.addEventListener('click', function(){
+    mobileNav.classList.toggle('open');
+    var isOpen = mobileNav.classList.contains('open');
+    hamburger.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+    if(isOpen){
+      hamburger.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+    } else {
+      hamburger.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+    }
+  });
+
+  mobileNav.addEventListener('click', function(e){
+    if(e.target.tagName === 'A'){
+      mobileNav.classList.remove('open');
+      hamburger.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+      hamburger.setAttribute('aria-label', 'Open menu');
+    }
+  });
+})();
+
+/* ── Active section highlight ─────────────────────── */
+(function(){
+  var links = document.querySelectorAll('.nav-links a');
+  var sections = [];
+  links.forEach(function(link){
+    var id = link.getAttribute('href').replace('#','');
+    var el = document.getElementById(id);
+    if(el) sections.push({el: el, link: link});
+  });
+
+  if(!('IntersectionObserver' in window)) return;
+
+  var observer = new IntersectionObserver(function(entries){
+    entries.forEach(function(entry){
+      if(entry.isIntersecting){
+        links.forEach(function(l){ l.classList.remove('active'); });
+        sections.forEach(function(s){
+          if(s.el === entry.target) s.link.classList.add('active');
+        });
+      }
+    });
+  }, {rootMargin: '-80px 0px -60% 0px', threshold: 0});
+
+  sections.forEach(function(s){ observer.observe(s.el); });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a static single-file landing page (`site/index.html`) for GitHub Pages deployment, closes #61
- Includes dark/light theme toggle, responsive layout, smooth scroll navigation, copy-to-clipboard buttons
- Hero section with `npm i -g` install CTA, 4-card features grid, 12-item audit checks grid, faux terminal example output, quick start section with CLI flags table and GitHub Action snippet
- Footer with "Contribute on GitHub" button encouraging community contributions
- SVG favicon (`site/favicon.svg`) and GitHub Actions workflow (`.github/workflows/deploy-site.yml`) for automated deployment

## Files added

| File | Purpose |
|------|---------|
| `site/index.html` | Single-file landing page (HTML + inline CSS + inline JS) |
| `site/favicon.svg` | Blue circle with `</>` monospace icon |
| `.github/workflows/deploy-site.yml` | GitHub Pages deploy on `site/**` changes to main |

## Setup required

After merging, set GitHub Pages source to **GitHub Actions** in repo Settings > Pages.

## Test plan

- [ ] Open `site/index.html` locally — all sections render correctly
- [ ] Toggle dark/light theme — all elements theme correctly
- [ ] Click copy buttons — clipboard contains correct text
- [ ] Resize to mobile — responsive layout, hamburger menu works
- [ ] Click nav links — smooth scroll to correct sections
- [ ] Verify hero shows `npm i -g vercel-seo-audit` as primary install command
- [ ] Verify footer "Contribute on GitHub" button links to repo