### PR TITLE
chore(ci): skip release-please for site-only changes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+    paths-ignore: ['site/**']
   workflow_run:
     workflows: ["CI"]
     types: [completed]


### PR DESCRIPTION
## Summary

- Adds `paths-ignore: ['site/**']` to release-please workflow trigger so site-only pushes to main don't trigger unnecessary release PRs
- Works alongside `exclude-paths` in `release-please-config.json` (added in #62) as a belt-and-suspenders approach

This push to main will also re-trigger release-please to open the 2.4.0 release PR (from the #62 feat commit). That release can then be merged to clear the pending state.