### PR TITLE
feat: add --fix flag with auto-fix suggestions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,13 @@
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { dirname, resolve } from 'node:path';
 import { Command } from 'commander';
 import { runAudit } from './runner.js';
-import { formatReport, formatJson, formatMarkdown, formatHtml, formatDiff, formatDiffJson } from './utils/output.js';
+import { formatReport, formatJson, formatMarkdown, formatHtml, formatDiff, formatDiffJson, formatFixes } from './utils/output.js';
 import { getExitCode } from './exitCode.js';
 import { parsePagesFlag } from './utils/parsePagesFlag.js';
 import { loadConfig } from './utils/config.js';
+import { generateFixes } from './fixes/index.js';
 import { USER_AGENT_PRESETS, DEFAULT_CRAWL_LIMIT } from './constants.js';
 import type { AuditFinding, AuditReport, DiffResult } from './types.js';
 
@@ -25,7 +27,9 @@ program
   .option('--report <format>', 'Write report to file: json, md, or html')
   .option('--crawl [limit]', 'Crawl sitemap URLs and audit each page (default: 50)')
   .option('--diff <path>', 'Compare against a previous report.json')
-  .action(async (urlArg: string | undefined, options: { json?: boolean; verbose?: boolean; strict?: boolean; timeout: string; pages?: string; userAgent?: string; report?: string; crawl?: boolean | string; diff?: string }) => {
+  .option('--fix', 'Show auto-fix suggestions for supported findings')
+  .option('--apply', 'Write suggested fixes to disk (requires --fix)')
+  .action(async (urlArg: string | undefined, options: { json?: boolean; verbose?: boolean; strict?: boolean; timeout: string; pages?: string; userAgent?: string; report?: string; crawl?: boolean | string; diff?: string; fix?: boolean; apply?: boolean }) => {
     // Load config file
     let config;
     try {
@@ -75,6 +79,12 @@ program
       }
     } else if (config?.pages) {
       pages = config.pages;
+    }
+
+    // Validate --apply requires --fix
+    if (options.apply && !options.fix) {
+      console.error('Error: --apply requires --fix');
+      process.exit(2);
     }
 
     // Merge report: CLI flag > config
@@ -164,6 +174,38 @@ program
           console.log(formatDiffJson(diff));
         } else {
           console.log(formatDiff(diff));
+        }
+      }
+
+      // Show fix suggestions if --fix
+      if (options.fix) {
+        const allFindings = auditReport.modules.flatMap((m) => m.findings);
+        const fixes = generateFixes(allFindings, auditReport.url);
+
+        console.log(formatFixes(fixes));
+
+        if (options.apply && fixes.length > 0) {
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          const answer = await new Promise<string>((res) => {
+            rl.question(`Write ${fixes.length} file(s) to disk? [y/N] `, res);
+          });
+          rl.close();
+
+          if (answer.toLowerCase() === 'y') {
+            for (const fix of fixes) {
+              const filePath = resolve(process.cwd(), fix.filePath);
+              if (existsSync(filePath)) {
+                console.log(`  Skipped ${fix.filePath} (already exists)`);
+                continue;
+              }
+              const dir = dirname(filePath);
+              mkdirSync(dir, { recursive: true });
+              writeFileSync(filePath, fix.content, 'utf-8');
+              console.log(`  Created ${fix.filePath}`);
+            }
+          } else {
+            console.log('  No files written.');
+          }
         }
       }
 

--- a/src/fixes/index.test.ts
+++ b/src/fixes/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { generateFixes } from './index.js';
+import type { AuditFinding } from '../types.js';
+
+function makeFinding(overrides: Partial<AuditFinding>): AuditFinding {
+  return {
+    code: 'ROBOTS_MISSING',
+    severity: 'error',
+    category: 'robots',
+    message: 'Test message',
+    explanation: 'Test explanation',
+    suggestion: 'Test suggestion',
+    ...overrides,
+  };
+}
+
+describe('generateFixes', () => {
+  it('returns fix for ROBOTS_MISSING', () => {
+    const findings = [makeFinding({ code: 'ROBOTS_MISSING' })];
+    const fixes = generateFixes(findings, 'https://example.com');
+
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0].code).toBe('ROBOTS_MISSING');
+    expect(fixes[0].filePath).toBe('public/robots.txt');
+    expect(fixes[0].content).toContain('User-agent: *');
+    expect(fixes[0].content).toContain('Allow: /');
+    expect(fixes[0].content).toContain('Sitemap: https://example.com/sitemap.xml');
+  });
+
+  it('returns fix for SITEMAP_MISSING', () => {
+    const findings = [makeFinding({ code: 'SITEMAP_MISSING', category: 'sitemap' })];
+    const fixes = generateFixes(findings, 'https://example.com');
+
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0].code).toBe('SITEMAP_MISSING');
+    expect(fixes[0].filePath).toBe('public/sitemap.xml');
+    expect(fixes[0].content).toContain('<loc>https://example.com/</loc>');
+    expect(fixes[0].content).toContain('<?xml version="1.0"');
+  });
+
+  it('returns fix for NEXTJS_TRAILING_SLASH_308', () => {
+    const findings = [makeFinding({ code: 'NEXTJS_TRAILING_SLASH_308', category: 'nextjs' })];
+    const fixes = generateFixes(findings, 'https://example.com');
+
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0].code).toBe('NEXTJS_TRAILING_SLASH_308');
+    expect(fixes[0].filePath).toBe('next.config.js');
+    expect(fixes[0].content).toContain('trailingSlash: true');
+  });
+
+  it('returns empty array for non-fixable codes', () => {
+    const findings = [
+      makeFinding({ code: 'CANONICAL_MISSING', category: 'metadata' }),
+      makeFinding({ code: 'FAVICON_MISSING', category: 'favicon' }),
+    ];
+    const fixes = generateFixes(findings, 'https://example.com');
+
+    expect(fixes).toHaveLength(0);
+  });
+
+  it('handles mixed fixable and non-fixable findings', () => {
+    const findings = [
+      makeFinding({ code: 'ROBOTS_MISSING' }),
+      makeFinding({ code: 'CANONICAL_MISSING', category: 'metadata' }),
+      makeFinding({ code: 'SITEMAP_MISSING', category: 'sitemap' }),
+      makeFinding({ code: 'TITLE_MISSING', category: 'metadata' }),
+    ];
+    const fixes = generateFixes(findings, 'https://example.com');
+
+    expect(fixes).toHaveLength(2);
+    expect(fixes.map((f) => f.code)).toEqual(['ROBOTS_MISSING', 'SITEMAP_MISSING']);
+  });
+
+  it('returns empty array for empty findings', () => {
+    const fixes = generateFixes([], 'https://example.com');
+    expect(fixes).toHaveLength(0);
+  });
+});

--- a/src/fixes/index.ts
+++ b/src/fixes/index.ts
@@ -1,0 +1,80 @@
+import type { AuditFinding, FixSuggestion, IssueCode } from '../types.js';
+
+type FixGenerator = (finding: AuditFinding, url: string) => FixSuggestion | null;
+
+function fixRobotsMissing(_finding: AuditFinding, url: string): FixSuggestion {
+  let sitemapUrl: string;
+  try {
+    const parsed = new URL(url);
+    sitemapUrl = `${parsed.origin}/sitemap.xml`;
+  } catch {
+    sitemapUrl = `${url}/sitemap.xml`;
+  }
+
+  return {
+    code: 'ROBOTS_MISSING',
+    filePath: 'public/robots.txt',
+    description: 'Create a robots.txt that allows all crawlers and references your sitemap',
+    content: `User-agent: *\nAllow: /\n\nSitemap: ${sitemapUrl}\n`,
+  };
+}
+
+function fixSitemapMissing(_finding: AuditFinding, url: string): FixSuggestion {
+  let loc: string;
+  try {
+    const parsed = new URL(url);
+    loc = parsed.origin + '/';
+  } catch {
+    loc = url;
+  }
+
+  return {
+    code: 'SITEMAP_MISSING',
+    filePath: 'public/sitemap.xml',
+    description: 'Create a basic sitemap.xml with your homepage',
+    content: `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${loc}</loc>
+  </url>
+</urlset>
+`,
+  };
+}
+
+function fixTrailingSlash308(_finding: AuditFinding, _url: string): FixSuggestion {
+  return {
+    code: 'NEXTJS_TRAILING_SLASH_308',
+    filePath: 'next.config.js',
+    description: 'Enable trailingSlash in Next.js config to avoid 308 redirects',
+    content: `/** @type {import('next').NextConfig} */
+const nextConfig = {
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;
+`,
+  };
+}
+
+const fixGenerators: Partial<Record<IssueCode, FixGenerator>> = {
+  ROBOTS_MISSING: fixRobotsMissing,
+  SITEMAP_MISSING: fixSitemapMissing,
+  NEXTJS_TRAILING_SLASH_308: fixTrailingSlash308,
+};
+
+export function generateFixes(findings: AuditFinding[], url: string): FixSuggestion[] {
+  const fixes: FixSuggestion[] = [];
+
+  for (const finding of findings) {
+    const generator = fixGenerators[finding.code];
+    if (generator) {
+      const fix = generator(finding, url);
+      if (fix) {
+        fixes.push(fix);
+      }
+    }
+  }
+
+  return fixes;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,13 @@ export interface AuditFinding {
   url?: string;
 }
 
+export interface FixSuggestion {
+  code: IssueCode;
+  filePath: string;
+  description: string;
+  content: string;
+}
+
 export interface AuditModuleResult {
   module: string;
   findings: AuditFinding[];

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { AuditFinding, AuditReport, DiffResult, IssueSeverity } from '../types.js';
+import type { AuditFinding, AuditReport, DiffResult, FixSuggestion, IssueSeverity } from '../types.js';
 
 const severityColors: Record<IssueSeverity, (text: string) => string> = {
   error: chalk.red,
@@ -324,4 +324,28 @@ export function formatDiff(diff: DiffResult): string {
 
 export function formatDiffJson(diff: DiffResult): string {
   return JSON.stringify(diff, null, 2);
+}
+
+export function formatFixes(fixes: FixSuggestion[]): string {
+  if (fixes.length === 0) {
+    return chalk.dim('\n  No auto-fixable issues found.\n');
+  }
+
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(chalk.bold.underline('Auto-fix suggestions'));
+  lines.push('');
+
+  for (const fix of fixes) {
+    lines.push(chalk.bold.cyan(`  File: ${fix.filePath}`));
+    lines.push(chalk.dim(`  ${fix.description}`));
+    lines.push('');
+    for (const line of fix.content.split('\n')) {
+      lines.push(chalk.green(`    ${line}`));
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- Add `--fix` CLI flag that shows auto-fix suggestions for common SEO issues (missing robots.txt, sitemap.xml, Next.js trailing slash)
- Add `--apply` flag (requires `--fix`) that writes suggested fixes to disk with user confirmation
- Supports three fixable issue codes: `ROBOTS_MISSING`, `SITEMAP_MISSING`, `NEXTJS_TRAILING_SLASH_308`

Closes #40

## Test plan
- [x] `npm run build` passes with no TS errors
- [x] `npm test` passes — all 344 tests green (6 new tests for fix generators)
- [x] Manual: `vercel-seo-audit <url> --fix` shows fix suggestions
- [x] Manual: `vercel-seo-audit <url> --fix --apply` prompts and writes files
- [x] Manual: `vercel-seo-audit <url> --apply` (without --fix) exits with error