### PR TITLE
fix(action): pass inputs through env, pin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,13 +22,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
       - id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -39,8 +39,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/README.md
+++ b/README.md
@@ -276,12 +276,14 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-v2.5.0
+      - uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-v2.5.0 # x-release-please-version
         with:
           url: https://your-site.com
           strict: true
           report: json
 ```
+
+The pinned tag is updated on each release.
 
 All inputs:
 
@@ -291,8 +293,7 @@ All inputs:
 | `strict` | no | `false` | Fail on warnings too |
 | `user-agent` | no | — | `googlebot`, `bingbot`, or custom string |
 | `pages` | no | — | Comma-separated page paths |
-| `report` | no | — | Write report file: `json`, `md`, or `html` |
-| `crawl` | no | — | Crawl sitemap URLs (number = page limit, default 50) |
+| `report` | no | — | Write report file: `json` or `md` |
 | `timeout` | no | `10000` | Request timeout in ms |
 | `verbose` | no | `false` | Show detailed output |
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: JosephDoUrden/vercel-seo-audit@v1
+      - uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-v2.5.0
         with:
           url: https://your-site.com
           strict: true

--- a/action.yml
+++ b/action.yml
@@ -61,11 +61,6 @@ runs:
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        if [ -z "$INPUT_URL" ]; then
-          echo "::error::url input is required"
-          exit 2
-        fi
-
         args=()
 
         if [ "$INPUT_STRICT" = "true" ]; then
@@ -93,8 +88,13 @@ runs:
         fi
 
         # "--" ends option parsing, so a url starting with "-" is a url, not a flag.
+        # An empty url sends nothing, the CLI then reads it from .seoauditrc.json or errors.
+        target=()
+        if [ -n "$INPUT_URL" ]; then
+          target=(-- "$INPUT_URL")
+        fi
         set +e
-        npx vercel-seo-audit@2.5.0 "${args[@]}" -- "$INPUT_URL" # x-release-please-version
+        npx vercel-seo-audit@2.5.0 "${args[@]}" "${target[@]}" # x-release-please-version
         EXIT_CODE=$?
         set -e
 

--- a/action.yml
+++ b/action.yml
@@ -43,51 +43,61 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 20
 
     - name: Run SEO Audit
       id: audit
       shell: bash
+      # Inputs go through env, not ${{ }} inside run, so a hostile value
+      # (PR title, branch name, dispatch input) cannot break out of the script.
+      env:
+        INPUT_URL: ${{ inputs.url }}
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_USER_AGENT: ${{ inputs.user-agent }}
+        INPUT_PAGES: ${{ inputs.pages }}
+        INPUT_REPORT: ${{ inputs.report }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        args="${{ inputs.url }}"
+        args=("$INPUT_URL")
 
-        if [ "${{ inputs.strict }}" = "true" ]; then
-          args="$args --strict"
+        if [ "$INPUT_STRICT" = "true" ]; then
+          args+=(--strict)
         fi
 
-        if [ -n "${{ inputs.user-agent }}" ]; then
-          args="$args --user-agent \"${{ inputs.user-agent }}\""
+        if [ -n "$INPUT_USER_AGENT" ]; then
+          args+=(--user-agent "$INPUT_USER_AGENT")
         fi
 
-        if [ -n "${{ inputs.pages }}" ]; then
-          args="$args --pages ${{ inputs.pages }}"
+        if [ -n "$INPUT_PAGES" ]; then
+          args+=(--pages "$INPUT_PAGES")
         fi
 
-        if [ -n "${{ inputs.report }}" ]; then
-          args="$args --report ${{ inputs.report }}"
+        if [ -n "$INPUT_REPORT" ]; then
+          args+=(--report "$INPUT_REPORT")
         fi
 
-        if [ "${{ inputs.timeout }}" != "10000" ]; then
-          args="$args --timeout ${{ inputs.timeout }}"
+        if [ "$INPUT_TIMEOUT" != "10000" ]; then
+          args+=(--timeout "$INPUT_TIMEOUT")
         fi
 
-        if [ "${{ inputs.verbose }}" = "true" ]; then
-          args="$args --verbose"
+        if [ "$INPUT_VERBOSE" = "true" ]; then
+          args+=(--verbose)
         fi
 
         set +e
-        eval npx vercel-seo-audit@latest $args
+        npx vercel-seo-audit@2.5.0 "${args[@]}" # x-release-please-version
         EXIT_CODE=$?
         set -e
 
         echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-        if [ -n "${{ inputs.report }}" ]; then
-          if [ "${{ inputs.report }}" = "json" ]; then
+        if [ -n "$INPUT_REPORT" ]; then
+          if [ "$INPUT_REPORT" = "json" ]; then
             echo "report-path=report.json" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.report }}" = "md" ]; then
+          elif [ "$INPUT_REPORT" = "md" ]; then
             echo "report-path=report.md" >> "$GITHUB_OUTPUT"
           fi
         fi

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,12 @@ runs:
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        args=("$INPUT_URL")
+        if [ -z "$INPUT_URL" ]; then
+          echo "::error::url input is required"
+          exit 2
+        fi
+
+        args=()
 
         if [ "$INPUT_STRICT" = "true" ]; then
           args+=(--strict)
@@ -79,7 +84,7 @@ runs:
           args+=(--report "$INPUT_REPORT")
         fi
 
-        if [ "$INPUT_TIMEOUT" != "10000" ]; then
+        if [ -n "$INPUT_TIMEOUT" ] && [ "$INPUT_TIMEOUT" != "10000" ]; then
           args+=(--timeout "$INPUT_TIMEOUT")
         fi
 
@@ -87,19 +92,19 @@ runs:
           args+=(--verbose)
         fi
 
+        # "--" ends option parsing, so a url starting with "-" is a url, not a flag.
         set +e
-        npx vercel-seo-audit@2.5.0 "${args[@]}" # x-release-please-version
+        npx vercel-seo-audit@2.5.0 "${args[@]}" -- "$INPUT_URL" # x-release-please-version
         EXIT_CODE=$?
         set -e
 
         echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-        if [ -n "$INPUT_REPORT" ]; then
-          if [ "$INPUT_REPORT" = "json" ]; then
-            echo "report-path=report.json" >> "$GITHUB_OUTPUT"
-          elif [ "$INPUT_REPORT" = "md" ]; then
-            echo "report-path=report.md" >> "$GITHUB_OUTPUT"
-          fi
+        # Only report a path for a file the audit actually wrote.
+        if [ "$INPUT_REPORT" = "json" ] && [ -f report.json ]; then
+          echo "report-path=report.json" >> "$GITHUB_OUTPUT"
+        elif [ "$INPUT_REPORT" = "md" ] && [ -f report.md ]; then
+          echo "report-path=report.md" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $EXIT_CODE
+        exit "$EXIT_CODE"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,7 +15,11 @@ to automate versioning, changelog generation, and GitHub releases.
 3. **Merge the release PR.**
    This creates a GitHub Release with a git tag (`vercel-seo-audit-v2.5.0`, etc.).
    Release-please bumps the `npx vercel-seo-audit@x.y.z` pin in `action.yml`
-   itself; the `uses:` examples in `README.md` and `site/index.html` are bumped
+   and the `uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-vx.y.z` line
+   in `README.md` (both carry an `x-release-please-version` marker). `site/` is
+   excluded from release-please, so the same `uses:` line inside the
+   "GitHub Action" quick-start `<code>` block in `site/index.html` (find it with
+   `grep -n 'uses: JosephDoUrden/vercel-seo-audit@' site/index.html`) is bumped
    by hand to the new tag.
 
 4. **npm publish runs automatically.**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,7 +13,10 @@ to automate versioning, changelog generation, and GitHub releases.
    manifest. It stays open and accumulates changes until you're ready.
 
 3. **Merge the release PR.**
-   This creates a GitHub Release with a git tag (`v0.6.0`, etc.).
+   This creates a GitHub Release with a git tag (`vercel-seo-audit-v2.5.0`, etc.).
+   Release-please bumps the `npx vercel-seo-audit@x.y.z` pin in `action.yml`
+   itself; the `uses:` examples in `README.md` and `site/index.html` are bumped
+   by hand to the new tag.
 
 4. **npm publish runs automatically.**
    The `publish.yml` workflow triggers on the GitHub Release and publishes to

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
       "extra-files": [
         "src/cli.ts",
         "src/constants.ts",
-        "action.yml"
+        "action.yml",
+        "README.md"
       ],
       "exclude-paths": [
         "site"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         "src/cli.ts",
-        "src/constants.ts"
+        "src/constants.ts",
+        "action.yml"
       ],
       "exclude-paths": [
         "site"

--- a/site/index.html
+++ b/site/index.html
@@ -697,7 +697,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: JosephDoUrden/vercel-seo-audit@v1
+      - uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-v2.5.0
         with:
           url: https://your-site.com
           strict: true

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Guards the composite action against script injection: every input must
+// reach the shell through env, never through a ${{ }} expression inside run.
+// There is no YAML parser in the dependency tree, so the checks work on the
+// raw text of action.yml.
+
+const actionPath = join(import.meta.dirname, '..', 'action.yml');
+const actionYml = readFileSync(actionPath, 'utf8');
+const lines = actionYml.split('\n');
+
+function declaredInputs(): string[] {
+  const names: string[] = [];
+  let inInputs = false;
+  for (const line of lines) {
+    if (/^inputs:\s*$/.test(line)) { inInputs = true; continue; }
+    if (inInputs && /^\S/.test(line)) break;
+    const m = inInputs ? line.match(/^  ([a-z-]+):\s*$/) : null;
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+function runBlocks(): string[] {
+  const blocks: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*run:\s*\|\s*$/.test(lines[i])) continue;
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === '') j++;
+    const indent = lines[j].match(/^(\s*)/)![1];
+    const body: string[] = [];
+    for (; j < lines.length; j++) {
+      if (lines[j].trim() === '') { body.push(''); continue; }
+      if (!lines[j].startsWith(indent)) break;
+      body.push(lines[j].slice(indent.length));
+    }
+    blocks.push(body.join('\n'));
+  }
+  return blocks;
+}
+
+function envMappedInputs(): string[] {
+  const names: string[] = [];
+  for (const line of lines) {
+    const m = line.match(/^\s+[A-Z_]+:\s*\$\{\{\s*inputs\.([a-z-]+)\s*\}\}\s*$/);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+describe('action.yml (static)', () => {
+  it('has exactly one run block', () => {
+    expect(runBlocks()).toHaveLength(1);
+  });
+
+  it('never interpolates an expression into the shell script', () => {
+    for (const block of runBlocks()) {
+      expect(block).not.toContain('${{');
+    }
+  });
+
+  it('does not eval and does not float on @latest', () => {
+    const [script] = runBlocks();
+    expect(script).not.toMatch(/\beval\b/);
+    expect(script).not.toContain('@latest');
+    expect(script).toMatch(/npx vercel-seo-audit@\d+\.\d+\.\d+/);
+  });
+
+  it('passes every declared input through env', () => {
+    const declared = declaredInputs();
+    expect(declared.length).toBeGreaterThan(0);
+    expect(envMappedInputs().sort()).toEqual([...declared].sort());
+  });
+
+  it('only references inputs from env values', () => {
+    const refs = actionYml.match(/\$\{\{\s*inputs\.[a-z-]+\s*\}\}/g) ?? [];
+    expect(refs).toHaveLength(envMappedInputs().length);
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
+  let work: string;
+  let bin: string;
+  let argsFile: string;
+  let outputFile: string;
+
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), 'vsa-action-'));
+    bin = join(work, 'bin');
+    mkdirSync(bin);
+    argsFile = join(work, 'npx-args');
+    outputFile = join(work, 'github-output');
+    writeFileSync(outputFile, '');
+    // Stand-in for npx: record argv one per line, exit with NPX_EXIT_CODE.
+    writeFileSync(
+      join(bin, 'npx'),
+      '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$NPX_ARGS_FILE"\nexit "${NPX_EXIT_CODE:-0}"\n',
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  function run(inputs: Record<string, string>, npxExit = 0) {
+    const [script] = runBlocks();
+    const scriptPath = join(work, 'step.sh');
+    writeFileSync(scriptPath, script);
+    const env: Record<string, string> = {
+      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      GITHUB_OUTPUT: outputFile,
+      NPX_ARGS_FILE: argsFile,
+      NPX_EXIT_CODE: String(npxExit),
+      INPUT_URL: '',
+      INPUT_STRICT: 'false',
+      INPUT_USER_AGENT: '',
+      INPUT_PAGES: '',
+      INPUT_REPORT: '',
+      INPUT_TIMEOUT: '10000',
+      INPUT_VERBOSE: 'false',
+      ...inputs,
+    };
+    // Same invocation GitHub uses for `shell: bash` in a composite action.
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-eo', 'pipefail', scriptPath], {
+      cwd: work,
+      env,
+      encoding: 'utf8',
+    });
+    const argv = existsSync(argsFile) ? readFileSync(argsFile, 'utf8').split('\n').slice(0, -1) : null;
+    return { status: result.status, stderr: result.stderr, argv, output: readFileSync(outputFile, 'utf8') };
+  }
+
+  it('passes hostile input to npx as literal arguments', () => {
+    const url = 'https://x.test/$(touch canary-a); touch canary-b #';
+    const ua = 'Mozilla `touch canary-c` "x" $HOME';
+    const pages = '/a,/b; touch canary-d';
+    const r = run({
+      INPUT_URL: url,
+      INPUT_STRICT: 'true',
+      INPUT_USER_AGENT: ua,
+      INPUT_PAGES: pages,
+      INPUT_REPORT: 'json',
+      INPUT_TIMEOUT: '5000',
+      INPUT_VERBOSE: 'true',
+    });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      url,
+      '--strict',
+      '--user-agent', ua,
+      '--pages', pages,
+      '--report', 'json',
+      '--timeout', '5000',
+      '--verbose',
+    ]);
+    for (const c of ['canary-a', 'canary-b', 'canary-c', 'canary-d']) {
+      expect(existsSync(join(work, c)), c).toBe(false);
+    }
+    expect(r.output).toContain('exit-code=0\n');
+    expect(r.output).toContain('report-path=report.json\n');
+  });
+
+  it('sends only the url when every optional input is at its default', () => {
+    const r = run({ INPUT_URL: 'https://example.com' });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toHaveLength(2);
+    expect(r.argv![1]).toBe('https://example.com');
+    expect(r.output).toBe('exit-code=0\n');
+  });
+
+  it('propagates the audit exit code and reports the md path', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_REPORT: 'md' }, 1);
+    expect(r.status).toBe(1);
+    expect(r.output).toContain('exit-code=1\n');
+    expect(r.output).toContain('report-path=report.md\n');
+  });
+});

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -215,12 +215,10 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
     expect(r.argv!.slice(1, sep)).toEqual(['--strict', '--report', 'md']);
   });
 
-  it('refuses an empty url instead of passing an empty argument', () => {
+  it('sends no url argument at all when the url input is empty', () => {
     const r = run({ INPUT_URL: '' });
-    expect(r.status).toBe(2);
-    expect(r.argv).toBeNull();
-    expect(r.stderr + r.stdout).toContain('::error::');
-    expect(r.output).toBe('');
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/)]);
   });
 
   it('omits --timeout when the timeout input is empty', () => {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -95,10 +95,17 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
     argsFile = join(work, 'npx-args');
     outputFile = join(work, 'github-output');
     writeFileSync(outputFile, '');
-    // Stand-in for npx: record argv one per line, exit with NPX_EXIT_CODE.
+    // Stand-in for npx: record argv one per line, optionally write the report
+    // file the real CLI would have written, exit with NPX_EXIT_CODE.
     writeFileSync(
       join(bin, 'npx'),
-      '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$NPX_ARGS_FILE"\nexit "${NPX_EXIT_CODE:-0}"\n',
+      [
+        '#!/bin/sh',
+        'printf \'%s\\n\' "$@" > "$NPX_ARGS_FILE"',
+        'if [ -n "$NPX_WRITE_REPORT" ]; then echo "{}" > "$NPX_WRITE_REPORT"; fi',
+        'exit "${NPX_EXIT_CODE:-0}"',
+        '',
+      ].join('\n'),
       { mode: 0o755 },
     );
   });
@@ -107,7 +114,7 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
     rmSync(work, { recursive: true, force: true });
   });
 
-  function run(inputs: Record<string, string>, npxExit = 0) {
+  function run(inputs: Record<string, string>, npxExit = 0, writeReport = '') {
     const [script] = runBlocks();
     const scriptPath = join(work, 'step.sh');
     writeFileSync(scriptPath, script);
@@ -116,6 +123,7 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
       GITHUB_OUTPUT: outputFile,
       NPX_ARGS_FILE: argsFile,
       NPX_EXIT_CODE: String(npxExit),
+      NPX_WRITE_REPORT: writeReport,
       INPUT_URL: '',
       INPUT_STRICT: 'false',
       INPUT_USER_AGENT: '',
@@ -132,7 +140,13 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
       encoding: 'utf8',
     });
     const argv = existsSync(argsFile) ? readFileSync(argsFile, 'utf8').split('\n').slice(0, -1) : null;
-    return { status: result.status, stderr: result.stderr, argv, output: readFileSync(outputFile, 'utf8') };
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      argv,
+      output: readFileSync(outputFile, 'utf8'),
+    };
   }
 
   it('passes hostile input to npx as literal arguments', () => {
@@ -147,17 +161,18 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
       INPUT_REPORT: 'json',
       INPUT_TIMEOUT: '5000',
       INPUT_VERBOSE: 'true',
-    });
+    }, 0, 'report.json');
     expect(r.status, r.stderr).toBe(0);
     expect(r.argv).toEqual([
       expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
-      url,
       '--strict',
       '--user-agent', ua,
       '--pages', pages,
       '--report', 'json',
       '--timeout', '5000',
       '--verbose',
+      '--',
+      url,
     ]);
     for (const c of ['canary-a', 'canary-b', 'canary-c', 'canary-d']) {
       expect(existsSync(join(work, c)), c).toBe(false);
@@ -169,15 +184,102 @@ describe.skipIf(process.platform === 'win32')('action.yml (executed)', () => {
   it('sends only the url when every optional input is at its default', () => {
     const r = run({ INPUT_URL: 'https://example.com' });
     expect(r.status, r.stderr).toBe(0);
-    expect(r.argv).toHaveLength(2);
-    expect(r.argv![1]).toBe('https://example.com');
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      '--',
+      'https://example.com',
+    ]);
     expect(r.output).toBe('exit-code=0\n');
   });
 
-  it('propagates the audit exit code and reports the md path', () => {
-    const r = run({ INPUT_URL: 'https://example.com', INPUT_REPORT: 'md' }, 1);
+  // A url that starts with "-" must reach the CLI as the positional argument,
+  // never as a flag (commander stops option parsing at "--").
+  it('passes a url that starts with a dash after the -- separator', () => {
+    const url = '--diff=../../../../../../../../etc/passwd';
+    const r = run({ INPUT_URL: url });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      '--',
+      url,
+    ]);
+    expect(r.argv!.indexOf('--')).toBeLessThan(r.argv!.indexOf(url));
+  });
+
+  it('keeps every flag before the -- separator', () => {
+    const r = run({ INPUT_URL: '-', INPUT_STRICT: 'true', INPUT_REPORT: 'md' });
+    expect(r.status, r.stderr).toBe(0);
+    const sep = r.argv!.indexOf('--');
+    expect(sep).toBeGreaterThan(0);
+    expect(r.argv!.slice(sep)).toEqual(['--', '-']);
+    expect(r.argv!.slice(1, sep)).toEqual(['--strict', '--report', 'md']);
+  });
+
+  it('refuses an empty url instead of passing an empty argument', () => {
+    const r = run({ INPUT_URL: '' });
+    expect(r.status).toBe(2);
+    expect(r.argv).toBeNull();
+    expect(r.stderr + r.stdout).toContain('::error::');
+    expect(r.output).toBe('');
+  });
+
+  it('omits --timeout when the timeout input is empty', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_TIMEOUT: '' });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      '--',
+      'https://example.com',
+    ]);
+  });
+
+  it('forwards a non-default timeout', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_TIMEOUT: '2500' });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      '--timeout', '2500',
+      '--',
+      'https://example.com',
+    ]);
+  });
+
+  it('omits every optional flag whose input is empty', () => {
+    const r = run({
+      INPUT_URL: 'https://example.com',
+      INPUT_STRICT: '',
+      INPUT_USER_AGENT: '',
+      INPUT_PAGES: '',
+      INPUT_REPORT: '',
+      INPUT_TIMEOUT: '',
+      INPUT_VERBOSE: '',
+    });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.argv).toEqual([
+      expect.stringMatching(/^vercel-seo-audit@\d+\.\d+\.\d+$/),
+      '--',
+      'https://example.com',
+    ]);
+    expect(r.output).toBe('exit-code=0\n');
+  });
+
+  it('propagates exit code 1 and reports the md path when the file was written', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_REPORT: 'md' }, 1, 'report.md');
     expect(r.status).toBe(1);
     expect(r.output).toContain('exit-code=1\n');
     expect(r.output).toContain('report-path=report.md\n');
+  });
+
+  it('does not report a path when the audit crashed without writing the file', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_REPORT: 'md' }, 2);
+    expect(r.status).toBe(2);
+    expect(r.output).toBe('exit-code=2\n');
+    expect(r.output).not.toContain('report-path');
+  });
+
+  it('does not report a path when the file is missing even on exit 0', () => {
+    const r = run({ INPUT_URL: 'https://example.com', INPUT_REPORT: 'json' }, 0);
+    expect(r.status).toBe(0);
+    expect(r.output).toBe('exit-code=0\n');
   });
 });


### PR DESCRIPTION
the action built a string from the inputs and ran it through eval, so anything in url or user-agent was shell on your own runner. inputs now go through env into an argv array, no eval, url goes after `--` so a dash value can't turn into a flag. empty inputs stay out of argv, report-path only if the file exists. npx call and third party actions pinned, release-please bumps the pins. consumers get this at 2.6.0.
