### PR TITLE
ci: publish to npm with trusted publishing instead of a token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,8 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    # Runs after a release, or by hand when a release exists on npm's side but the publish failed.
+    if: needs.release-please.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,22 +46,19 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
+      # Trusted publishing (OIDC) needs npm 11.5.1 or newer; Node 22 ships npm 10.
+      - run: npm install -g npm@11
+      - run: npm --version
       - run: npm ci
       - run: npm run build
       - run: npm test
+      # No token: npm authenticates the job through GitHub's OIDC token (trusted publisher set on
+      # npmjs.com for this repo and workflow file). Provenance is attached automatically.
       - name: Publish to npm
-        if: env.NODE_AUTH_TOKEN != ''
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if npm view "vercel-seo-audit@${VERSION}" version >/dev/null 2>&1; then
-            echo "::warning::v${VERSION} already published — skipping."
+            echo "::warning::v${VERSION} already published, skipping."
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Skip publish (no token)
-        if: env.NODE_AUTH_TOKEN == ''
-        run: echo "::warning::NPM_TOKEN secret not set — skipping npm publish."
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,8 +23,12 @@ to automate versioning, changelog generation, and GitHub releases.
    by hand to the new tag.
 
 4. **npm publish runs automatically.**
-   The `publish.yml` workflow triggers on the GitHub Release and publishes to
-   npm using the `NPM_TOKEN` secret.
+   The `publish` job in `release-please.yml` runs once the release exists and
+   publishes with npm trusted publishing: the job authenticates through GitHub's
+   OIDC token, no npm token is stored anywhere, and provenance is attached. If the
+   release was created but the publish failed, run the workflow by hand
+   (Actions → Release Please → Run workflow); the job skips versions that are
+   already on npm.
 
 ## Commit message format
 
@@ -45,12 +49,13 @@ commit type determines how the version is bumped:
 
 ## Required secrets
 
-| Secret | Where | Purpose |
-| ------ | ----- | ------- |
-| `NPM_TOKEN` | Repository → Settings → Secrets → Actions | npm publish authentication |
+None for npm. Publishing uses a trusted publisher configured once on npmjs.com
+(package → Settings → Trusted publisher → GitHub Actions, owner `JosephDoUrden`,
+repository `vercel-seo-audit`, workflow `release-please.yml`, no environment).
+Requires npm 11.5.1 or newer on the runner, which the job installs.
 
-The publish workflow is fork-safe — if `NPM_TOKEN` is not set, it prints a
-warning and skips the publish step.
+`RELEASE_PLEASE_TOKEN` (a fine-grained GitHub token) is still needed so the
+release PR can trigger CI.
 
 ## Required repository permissions
 
@@ -71,5 +76,5 @@ npm version patch  # or minor / major
 git push origin main --tags
 
 # 3. Create a GitHub Release from the tag
-#    → this triggers npm publish via publish.yml
+#    → then run the Release Please workflow by hand to publish
 ```


### PR DESCRIPTION
the 2.5.1 publish died with a 404 on PUT, which is npm saying the token is no good. this drops the token entirely and publishes through the trusted publisher set up on npmjs.com, same as webhook-hmac-kit. job installs npm 11 for the oidc bit and can be run by hand from the Actions tab when a release exists but the publish failed, it skips versions already on npm.
