### PR TITLE
fix(audit): only flag external classic scripts as render-blocking

### DIFF
--- a/src/audit/performance.test.ts
+++ b/src/audit/performance.test.ts
@@ -82,6 +82,68 @@ describe('auditPerformance', () => {
     expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
   });
 
+  it('does not flag JSON-LD data blocks', async () => {
+    const ld = '<script type="application/ld+json">{"@context":"https://schema.org"}</script>';
+    const html = `<html><head>${ld}${ld}${ld}</head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+  });
+
+  it('does not flag importmap or speculationrules', async () => {
+    const html = `<html><head><script type="importmap">{"imports":{}}</script><script type="speculationrules">{"prerender":[]}</script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+  });
+
+  it('does not flag inline scripts without src', async () => {
+    const html = `<html><head><script>window.dataLayer = [];</script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+  });
+
+  it('flags external scripts with an explicit JavaScript type', async () => {
+    const html = `<html><head><script type="text/javascript" src="/legacy.js"></script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeDefined();
+  });
+
+  it('reads attributes, not substrings of attribute values', async () => {
+    const html = `<html><head><script src="/vendor/async-defer.js"></script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeDefined();
+  });
+
+  it('treats an empty type as classic and a MIME parameter or blank type as a data block', async () => {
+    const empty = `<html><head><script type="" src="/a.js"></script></head><body></body></html>`;
+    const param = `<html><head><script type="text/javascript; charset=utf-8" src="/a.js"></script></head><body></body></html>`;
+    const blank = `<html><head><script type="   " src="/a.js"></script></head><body></body></html>`;
+    expect((await auditPerformance(makeCtx(empty))).find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeDefined();
+    expect((await auditPerformance(makeCtx(param))).find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+    expect((await auditPerformance(makeCtx(blank))).find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+  });
+
+  it('does not read script tags out of JSON-LD text or comments', async () => {
+    const html = `<html><head><!-- <script src="/old.js"></script> --><script type="application/ld+json">{"d":"<script src=\\"/x.js\\">"}</script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    expect(findings.find((f) => f.code === 'RENDER_BLOCKING_SCRIPT')).toBeUndefined();
+  });
+
+  it('uses the singular message for one script', async () => {
+    const html = `<html><head><script src="/a.js"></script></head><body></body></html>`;
+    const f = (await auditPerformance(makeCtx(html))).find((f) => f.code === 'RENDER_BLOCKING_SCRIPT');
+    expect(f!.message).toBe('1 render-blocking <script> tag in <head> without async or defer');
+    expect(f!.details).toEqual({ count: 1, srcs: ['/a.js'] });
+  });
+
+  it('collapses several blocking scripts into one finding with a count', async () => {
+    const html = `<html><head><script src="/a.js"></script><script src=/b.js></script><script src="/c.js" defer></script></head><body></body></html>`;
+    const findings = await auditPerformance(makeCtx(html));
+    const hits = findings.filter((f) => f.code === 'RENDER_BLOCKING_SCRIPT');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].details).toEqual({ count: 2, srcs: ['/a.js', '/b.js'] });
+    expect(hits[0].message).toContain('2 render-blocking');
+  });
+
   it('detects large inline style', async () => {
     const bigCss = 'a'.repeat(51 * 1024);
     const html = `<html><head><style>${bigCss}</style></head><body></body></html>`;

--- a/src/audit/performance.ts
+++ b/src/audit/performance.ts
@@ -1,8 +1,39 @@
 import type { AuditContext, AuditFinding } from '../types.js';
 import { fetchPage } from '../utils/http.js';
+import { getHeadScripts } from '../utils/html-parser.js';
 
 const KB = 1024;
 const MB = 1024 * KB;
+
+// JavaScript MIME type essences per the HTML spec. A <script> with any other type is a data block.
+const JAVASCRIPT_MIME_TYPES = new Set([
+  'application/ecmascript',
+  'application/javascript',
+  'application/x-ecmascript',
+  'application/x-javascript',
+  'text/ecmascript',
+  'text/javascript',
+  'text/javascript1.0',
+  'text/javascript1.1',
+  'text/javascript1.2',
+  'text/javascript1.3',
+  'text/javascript1.4',
+  'text/javascript1.5',
+  'text/jscript',
+  'text/livescript',
+  'text/x-ecmascript',
+  'text/x-javascript',
+]);
+
+/**
+ * No type or an empty type means a classic script; otherwise the trimmed value has to be a
+ * JavaScript MIME type essence. A whitespace-only type trims to nothing and is a data block,
+ * which is also what browsers do.
+ */
+function isClassicScript(type: string | null): boolean {
+  if (type === null || type === '') return true;
+  return JAVASCRIPT_MIME_TYPES.has(type.trim().toLowerCase());
+}
 
 export async function auditPerformance(ctx: AuditContext): Promise<AuditFinding[]> {
   const findings: AuditFinding[] = [];
@@ -50,31 +81,25 @@ export async function auditPerformance(ctx: AuditContext): Promise<AuditFinding[
     });
   }
 
-  // 2. Render-blocking scripts in <head>
-  const headMatch = html.match(/<head[\s>]([\s\S]*?)<\/head>/i);
-  if (headMatch) {
-    const headContent = headMatch[1];
-    const scriptRegex = /<script\b([^>]*)>/gi;
-    let match;
-    while ((match = scriptRegex.exec(headContent)) !== null) {
-      const attrs = match[1];
-      const hasAsync = /\basync\b/i.test(attrs);
-      const hasDefer = /\bdefer\b/i.test(attrs);
-      const hasTypeModule = /\btype\s*=\s*["']module["']/i.test(attrs);
-      if (!hasAsync && !hasDefer && !hasTypeModule) {
-        findings.push({
-          code: 'RENDER_BLOCKING_SCRIPT',
-          severity: 'warning',
-          category: 'performance',
-          message: 'Render-blocking <script> found in <head> without async, defer, or type="module"',
-          explanation:
-            'Scripts in <head> without async or defer block HTML parsing until they are downloaded and executed, delaying First Contentful Paint.',
-          suggestion:
-            'Add the async or defer attribute to <script> tags in <head>, or move them to the end of <body>.',
-          url: normalizedUrl,
-        });
-      }
-    }
+  // 2. Render-blocking scripts in <head>: external classic scripts without async or defer.
+  // Inline scripts have nothing to download, and data blocks (ld+json, importmap,
+  // speculationrules, any non-JavaScript type) are never executed, so none of them qualify.
+  const blocking = getHeadScripts(html)
+    .filter((s) => s.src && !s.async && !s.defer && isClassicScript(s.type))
+    .map((s) => s.src as string);
+  if (blocking.length > 0) {
+    findings.push({
+      code: 'RENDER_BLOCKING_SCRIPT',
+      severity: 'warning',
+      category: 'performance',
+      message: `${blocking.length} render-blocking <script> tag${blocking.length === 1 ? '' : 's'} in <head> without async or defer`,
+      explanation:
+        'External scripts in <head> without async or defer block HTML parsing until they are downloaded and executed, delaying First Contentful Paint.',
+      suggestion:
+        'Add the async or defer attribute to <script> tags in <head>, use type="module", or move them to the end of <body>.',
+      url: normalizedUrl,
+      details: { count: blocking.length, srcs: blocking },
+    });
   }
 
   // 3. Large inline styles

--- a/src/utils/html-parser.test.ts
+++ b/src/utils/html-parser.test.ts
@@ -10,6 +10,7 @@ import {
   getFaviconLinks,
   getHreflangLinks,
   getImages,
+  getHeadScripts,
 } from './html-parser.js';
 
 function html(head: string): string {
@@ -329,5 +330,30 @@ describe('getImages', () => {
   it('skips images without src', () => {
     const images = getImages(body('<img alt="no src">'));
     expect(images).toHaveLength(0);
+  });
+});
+
+describe('getHeadScripts', () => {
+  it('extracts src, type and the boolean attributes', () => {
+    const scripts = getHeadScripts(
+      html('<script src="/a.js"></script><script type="application/ld+json">{}</script><script src="/b.js" async defer></script>')
+    );
+    expect(scripts).toEqual([
+      { src: '/a.js', type: null, async: false, defer: false },
+      { src: null, type: 'application/ld+json', async: false, defer: false },
+      { src: '/b.js', type: null, async: true, defer: true },
+    ]);
+  });
+
+  it('ignores scripts in body and in comments', () => {
+    const scripts = getHeadScripts(
+      '<html><head><!-- <script src="/old.js"></script> --></head><body><script src="/body.js"></script></body></html>'
+    );
+    expect(scripts).toHaveLength(0);
+  });
+
+  it('keeps a > inside a quoted attribute value', () => {
+    const scripts = getHeadScripts(html('<script data-cfg="a>b" src="/a.js"></script>'));
+    expect(scripts).toEqual([{ src: '/a.js', type: null, async: false, defer: false }]);
   });
 });

--- a/src/utils/html-parser.ts
+++ b/src/utils/html-parser.ts
@@ -121,6 +121,27 @@ export function getImages(html: string): ImageInfo[] {
   return images;
 }
 
+export interface HeadScript {
+  src: string | null;
+  type: string | null;
+  async: boolean;
+  defer: boolean;
+}
+
+export function getHeadScripts(html: string): HeadScript[] {
+  const $ = cheerio.load(html);
+  const scripts: HeadScript[] = [];
+  $('head script').each((_, el) => {
+    scripts.push({
+      src: $(el).attr('src') ?? null,
+      type: $(el).attr('type') ?? null,
+      async: $(el).attr('async') !== undefined,
+      defer: $(el).attr('defer') !== undefined,
+    });
+  });
+  return scripts;
+}
+
 export function getHreflangLinks(html: string): HreflangLink[] {
   const $ = cheerio.load(html);
   const links: HreflangLink[] = [];


### PR DESCRIPTION
the render-blocking check matched every script in head that had no async or defer, so json-ld, importmap and speculationrules blocks all came back as warnings and `--strict` failed on sites doing exactly what google recommends. three json-ld blocks was three warnings.

now it needs a src and a javascript type (or no type) before it counts, and it reads attributes through cheerio instead of looking for the word async anywhere in the tag. several hits collapse into one finding with count and srcs in details, same shape as the image checks.

tests for each data block type, inline scripts, blank and parameterised types, comments, and the collapse.
