### PR TITLE
perf(audit): fetch the page once and share it across modules

### DIFF
--- a/src/audit/crawl.test.ts
+++ b/src/audit/crawl.test.ts
@@ -43,6 +43,28 @@ const GOOD_HTML = `<html><head>
 
 const BAD_HTML = '<html><head></head><body></body></html>';
 
+describe('auditCrawl fetch options', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetchPage.mockResolvedValue(makePage(GOOD_HTML, { finalUrl: 'https://example.com/page-1' }));
+  });
+
+  it('fetches crawled pages without the audit cache', async () => {
+    const ctx = makeCtx({
+      sitemapUrls: ['https://example.com/page-1'],
+      fetchOptions: { timeout: 1234, userAgent: 'bot', cache: new Map() },
+    });
+
+    await auditCrawl(ctx);
+
+    expect(mockFetchPage).toHaveBeenCalledWith('https://example.com/page-1', {
+      timeout: 1234,
+      userAgent: 'bot',
+    });
+    expect(ctx.fetchOptions.cache?.size).toBe(0);
+  });
+});
+
 function makeGoodHtml(pageUrl: string): string {
   return `<html><head>
   <title>Test Page</title>

--- a/src/audit/crawl.ts
+++ b/src/audit/crawl.ts
@@ -50,8 +50,11 @@ async function auditPage(
   let body: string;
   let status: number;
   let headers: Headers;
+  // Each crawled page is fetched once, so the audit cache would only pin every
+  // body in memory until the audit ends.
+  const { timeout, userAgent } = ctx.fetchOptions;
   try {
-    const res = await fetchPage(pageUrl, ctx.fetchOptions);
+    const res = await fetchPage(pageUrl, { timeout, userAgent });
     body = res.body;
     status = res.status;
     headers = res.headers;

--- a/src/audit/metadata.test.ts
+++ b/src/audit/metadata.test.ts
@@ -280,4 +280,34 @@ describe('auditMetadata', () => {
     const findings = await auditMetadata(makeCtx());
     expect(findings.find((f) => f.code === 'CANONICAL_MISMATCH')).toBeUndefined();
   });
+
+  it('uses the shared page from ctx instead of fetching', async () => {
+    mockFetchHead.mockResolvedValue({ status: 200, headers: new Headers() });
+    const ctx = makeCtx({
+      html: FULL_HTML,
+      headers: { 'x-robots-tag': 'noindex' },
+      finalUrl: 'https://example.com/',
+    });
+
+    const findings = await auditMetadata(ctx);
+
+    expect(mockFetchPage).not.toHaveBeenCalled();
+    expect(findings.find((f) => f.code === 'X_ROBOTS_NOINDEX')).toBeDefined();
+    expect(findings.find((f) => f.code === 'CANONICAL_MISMATCH')).toBeUndefined();
+  });
+
+  it('resolves canonical against ctx.finalUrl when the shared page was redirected', async () => {
+    mockFetchHead.mockResolvedValue({ status: 200, headers: new Headers() });
+    const ctx = makeCtx({
+      html: '<html><head><link rel="canonical" href="/"></head></html>',
+      headers: {},
+      finalUrl: 'https://www.example.com/',
+    });
+
+    const findings = await auditMetadata(ctx);
+    const mismatch = findings.find((f) => f.code === 'CANONICAL_MISMATCH');
+
+    expect(mockFetchPage).not.toHaveBeenCalled();
+    expect(mismatch).toBeUndefined();
+  });
 });

--- a/src/audit/metadata.ts
+++ b/src/audit/metadata.ts
@@ -18,15 +18,22 @@ export async function auditMetadata(ctx: AuditContext): Promise<AuditFinding[]> 
   let headers: Headers;
   let finalUrl: string;
 
-  try {
-    const page = await fetchPage(normalizedUrl, fetchOptions);
-    html = page.body;
-    headers = page.headers;
-    finalUrl = page.finalUrl;
-    ctx.html = html;
-    ctx.headers = Object.fromEntries(headers.entries());
-  } catch {
-    return findings;
+  if (ctx.html && ctx.headers) {
+    html = ctx.html;
+    headers = new Headers(ctx.headers);
+    finalUrl = ctx.finalUrl ?? normalizedUrl;
+  } else {
+    try {
+      const page = await fetchPage(normalizedUrl, fetchOptions);
+      html = page.body;
+      headers = page.headers;
+      finalUrl = page.finalUrl;
+      ctx.html = html;
+      ctx.headers = Object.fromEntries(headers.entries());
+      ctx.finalUrl = finalUrl;
+    } catch {
+      return findings;
+    }
   }
 
   // 1. Noindex check — meta tag

--- a/src/audit/redirects.test.ts
+++ b/src/audit/redirects.test.ts
@@ -274,4 +274,14 @@ describe('auditRedirects', () => {
     const nonPass = findings.filter((f) => f.severity !== 'pass' && f.severity !== 'info');
     expect(nonPass).toHaveLength(0);
   });
+
+  it('checks meta refresh on the shared page without fetching again', async () => {
+    mockGetMetaRefresh.mockReturnValue('https://example.com/new');
+
+    const findings = await auditRedirects(makeCtx({ html: '<html>shared</html>' }));
+
+    expect(mockFetchPage).not.toHaveBeenCalled();
+    expect(mockGetMetaRefresh).toHaveBeenCalledWith('<html>shared</html>');
+    expect(findings.find((f) => f.code === 'META_REFRESH_REDIRECT')).toBeDefined();
+  });
 });

--- a/src/audit/redirects.ts
+++ b/src/audit/redirects.ts
@@ -111,8 +111,8 @@ export async function auditRedirects(ctx: AuditContext): Promise<AuditFinding[]>
 
   // 4. Meta refresh detection
   try {
-    const page = await fetchPage(normalizedUrl, fetchOptions);
-    const metaRefreshUrl = getMetaRefresh(page.body);
+    const html = ctx.html ?? (await fetchPage(normalizedUrl, fetchOptions)).body;
+    const metaRefreshUrl = getMetaRefresh(html);
 
     if (metaRefreshUrl) {
       findings.push({

--- a/src/runner.requests.test.ts
+++ b/src/runner.requests.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { runAudit } from './runner.js';
@@ -11,6 +11,7 @@ import { runAudit } from './runner.js';
 let server: Server;
 let origin = '';
 const counts = new Map<string, number>();
+let flakyHits = 0;
 
 function page(withMarkers: boolean): string {
   return `<!DOCTYPE html>
@@ -62,6 +63,12 @@ beforeAll(async () => {
         return send(200, 'text/html; charset=utf-8', page(true));
       case '/plain':
         return send(200, 'text/html; charset=utf-8', page(false));
+      case '/flaky':
+        // First GET fails, every later one serves the page.
+        if (req.method === 'GET' && flakyHits++ === 0) {
+          return send(500, 'text/plain', 'boom');
+        }
+        return send(200, 'text/html; charset=utf-8', page(true));
       case '/robots.txt':
         return send(200, 'text/plain', `User-agent: *\nAllow: /\nSitemap: ${origin}/sitemap.xml\n`);
       case '/sitemap.xml':
@@ -91,9 +98,13 @@ afterAll(async () => {
   );
 });
 
+beforeEach(() => {
+  counts.clear();
+  flakyHits = 0;
+});
+
 describe('request count for a single-URL audit', () => {
   it('fetches the page once and shares it across modules', async () => {
-    counts.clear();
     const report = await runAudit(`${origin}/`, { timeout: 5000 });
     const { total, byPath } = snapshot();
 
@@ -121,6 +132,18 @@ describe('request count for a single-URL audit', () => {
 
     expect(finding).toBeDefined();
     expect(finding).toMatchObject({ severity: 'info', category: 'nextjs', url: `${origin}/plain` });
+  });
+
+  it('does not share a non-2xx first response with the modules', async () => {
+    const report = await runAudit(`${origin}/flaky`, { timeout: 5000 });
+    const metadata = report.modules.find((m) => m.module === 'metadata');
+    const codes = metadata?.findings.map((f) => f.code) ?? [];
+
+    // The 500 is retried, not analysed: the modules see the real page.
+    expect(counts.get('GET /flaky')).toBe(2);
+    expect(codes).not.toContain('TITLE_MISSING');
+    expect(codes).not.toContain('DESCRIPTION_MISSING');
+    expect(codes).not.toContain('CANONICAL_MISSING');
   });
 
   it('does not report APP_ROUTER_METADATA when the markers are present', async () => {

--- a/src/runner.requests.test.ts
+++ b/src/runner.requests.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { runAudit } from './runner.js';
+
+// A small Next.js-like site served from 127.0.0.1. Every request is counted by
+// method and path so the test can assert how many round trips one audit costs.
+// Before the shared fetch a single-URL audit made 34 requests, 19 of them for
+// the page itself.
+
+let server: Server;
+let origin = '';
+const counts = new Map<string, number>();
+
+function page(withMarkers: boolean): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Harness</title>
+  <meta name="description" content="Request count harness">
+  <link rel="canonical" href="${origin}/">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Harness">
+  <meta property="og:description" content="Request count harness">
+  <meta property="og:image" content="${origin}/og.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="${origin}/og.png">
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Harness","url":"${origin}/"}</script>
+</head>
+<body>
+  <div${withMarkers ? ' id="__next"' : ''}><img src="${origin}/hero.png" alt="Hero" width="800" height="600"></div>
+  ${withMarkers ? '<script src="/_next/static/chunks/main.js" defer></script>' : ''}
+</body>
+</html>`;
+}
+
+function snapshot(): { total: number; byPath: Record<string, number> } {
+  const total = [...counts.values()].reduce((a, b) => a + b, 0);
+  const byPath = Object.fromEntries([...counts.entries()].sort());
+  return { total, byPath };
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const path = new URL(req.url ?? '/', 'http://127.0.0.1').pathname;
+    const key = `${req.method} ${path}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+
+    const send = (status: number, type: string, body: string) => {
+      res.writeHead(status, {
+        'content-type': type,
+        'content-length': Buffer.byteLength(body),
+        'x-powered-by': 'Next.js',
+      });
+      res.end(req.method === 'HEAD' ? undefined : body);
+    };
+
+    switch (path) {
+      case '/':
+        return send(200, 'text/html; charset=utf-8', page(true));
+      case '/plain':
+        return send(200, 'text/html; charset=utf-8', page(false));
+      case '/robots.txt':
+        return send(200, 'text/plain', `User-agent: *\nAllow: /\nSitemap: ${origin}/sitemap.xml\n`);
+      case '/sitemap.xml':
+        return send(
+          200,
+          'application/xml',
+          `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>${origin}/</loc></url></urlset>`,
+        );
+      case '/favicon.ico':
+        return send(200, 'image/x-icon', 'icon');
+      case '/hero.png':
+      case '/og.png':
+        return send(200, 'image/png', 'x'.repeat(1000));
+      default:
+        return send(404, 'text/plain', 'not found');
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  origin = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+describe('request count for a single-URL audit', () => {
+  it('fetches the page once and shares it across modules', async () => {
+    counts.clear();
+    const report = await runAudit(`${origin}/`, { timeout: 5000 });
+    const { total, byPath } = snapshot();
+
+    expect(report.modules.map((m) => m.module)).toContain('metadata');
+
+    // The page itself: one GET, reused by every module and by the redirect
+    // chain and trailing-slash probes that hit the same URL.
+    expect(byPath['GET /']).toBe(1);
+    // robots.txt and sitemap.xml are read once each.
+    expect(byPath['GET /robots.txt']).toBe(1);
+    expect(byPath['GET /sitemap.xml']).toBe(1);
+    // og:image and twitter:image point at the same file: one HEAD.
+    expect(byPath['HEAD /og.png']).toBe(1);
+    // Four common-page probes are separate URLs and stay.
+    expect(byPath['GET /about']).toBe(1);
+
+    // 11 on a clean run; a little headroom for platform differences.
+    expect(total).toBeLessThanOrEqual(12);
+  });
+
+  it('reports APP_ROUTER_METADATA from the shared HTML when Next.js markers are absent', async () => {
+    const report = await runAudit(`${origin}/plain`, { timeout: 5000 });
+    const nextjs = report.modules.find((m) => m.module === 'nextjs');
+    const finding = nextjs?.findings.find((f) => f.code === 'APP_ROUTER_METADATA');
+
+    expect(finding).toBeDefined();
+    expect(finding).toMatchObject({ severity: 'info', category: 'nextjs', url: `${origin}/plain` });
+  });
+
+  it('does not report APP_ROUTER_METADATA when the markers are present', async () => {
+    const report = await runAudit(`${origin}/`, { timeout: 5000 });
+    const nextjs = report.modules.find((m) => m.module === 'nextjs');
+
+    expect(nextjs?.findings.find((f) => f.code === 'APP_ROUTER_METADATA')).toBeUndefined();
+  });
+});

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -249,6 +249,21 @@ describe('runAudit', () => {
     expect(mockMetadata.mock.calls[0][0].fetchOptions.cache).toBe(cache);
   });
 
+  it('does not share a non-2xx page and empties the cache so modules refetch', async () => {
+    mockFetchPage.mockImplementation(async (_url, fetchOptions) => {
+      fetchOptions?.cache?.set('MANUAL https://example.com/', Promise.resolve(undefined));
+      return { body: 'boom', status: 500, headers: new Headers(), finalUrl: 'https://example.com/' };
+    });
+
+    await runAudit('https://example.com');
+
+    const ctx = mockMetadata.mock.calls[0][0];
+    expect(ctx.html).toBeUndefined();
+    expect(ctx.headers).toBeUndefined();
+    expect(ctx.finalUrl).toBeUndefined();
+    expect(ctx.fetchOptions.cache?.size).toBe(0);
+  });
+
   it('leaves the shared page unset when the up-front fetch fails', async () => {
     mockFetchPage.mockRejectedValue(new Error('timeout'));
 

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runAudit } from './runner.js';
 
+vi.mock('./utils/http.js', () => ({
+  fetchPage: vi.fn(),
+}));
+
 vi.mock('./audit/index.js', () => ({
   auditRedirects: vi.fn(),
   auditRobots: vi.fn(),
@@ -16,6 +20,7 @@ vi.mock('./audit/index.js', () => ({
   auditPerformance: vi.fn(),
 }));
 
+import { fetchPage } from './utils/http.js';
 import {
   auditRedirects,
   auditRobots,
@@ -31,6 +36,7 @@ import {
   auditPerformance,
 } from './audit/index.js';
 
+const mockFetchPage = vi.mocked(fetchPage);
 const mockRedirects = vi.mocked(auditRedirects);
 const mockRobots = vi.mocked(auditRobots);
 const mockSitemap = vi.mocked(auditSitemap);
@@ -46,6 +52,13 @@ const mockPerformance = vi.mocked(auditPerformance);
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  mockFetchPage.mockResolvedValue({
+    body: '<html><head><title>Example</title></head></html>',
+    status: 200,
+    headers: new Headers({ 'x-powered-by': 'Next.js' }),
+    finalUrl: 'https://example.com/',
+  });
 
   // Default: all modules return empty findings
   mockRedirects.mockResolvedValue([]);
@@ -209,5 +222,42 @@ describe('runAudit', () => {
     expect(names).toContain('images');
     expect(names).toContain('security');
     expect(names).toContain('performance');
+  });
+
+  it('fetches the page once up front and shares it with every module', async () => {
+    await runAudit('https://example.com');
+
+    expect(mockFetchPage).toHaveBeenCalledTimes(1);
+    expect(mockFetchPage).toHaveBeenCalledWith(
+      'https://example.com/',
+      expect.objectContaining({ cache: expect.any(Map) }),
+    );
+
+    for (const mod of [mockRobots, mockRedirects, mockMetadata, mockNextjs, mockSecurity]) {
+      const ctx = mod.mock.calls[0][0];
+      expect(ctx.html).toBe('<html><head><title>Example</title></head></html>');
+      expect(ctx.headers).toEqual({ 'x-powered-by': 'Next.js' });
+      expect(ctx.finalUrl).toBe('https://example.com/');
+    }
+  });
+
+  it('gives every module the same per-audit fetch cache', async () => {
+    await runAudit('https://example.com');
+
+    const cache = mockRobots.mock.calls[0][0].fetchOptions.cache;
+    expect(cache).toBeInstanceOf(Map);
+    expect(mockMetadata.mock.calls[0][0].fetchOptions.cache).toBe(cache);
+  });
+
+  it('leaves the shared page unset when the up-front fetch fails', async () => {
+    mockFetchPage.mockRejectedValue(new Error('timeout'));
+
+    const report = await runAudit('https://example.com');
+
+    expect(report.modules.map((m) => m.module)).toContain('metadata');
+    const ctx = mockMetadata.mock.calls[0][0];
+    expect(ctx.html).toBeUndefined();
+    expect(ctx.headers).toBeUndefined();
+    expect(ctx.finalUrl).toBeUndefined();
   });
 });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -6,6 +6,7 @@ import type {
   FetchOptions,
 } from './types.js';
 import { normalizeUrl } from './utils/url.js';
+import { fetchPage } from './utils/http.js';
 import {
   auditRedirects,
   auditRobots,
@@ -72,6 +73,7 @@ export async function runAudit(
   const fetchOptions: FetchOptions = {
     timeout: opts.timeout,
     userAgent: opts.userAgent,
+    cache: new Map(),
   };
 
   const ctx: AuditContext = {
@@ -82,6 +84,17 @@ export async function runAudit(
     pages: opts.pages,
     crawlLimit: opts.crawl,
   };
+
+  // Phase 0: fetch the page once and share it. When this fails the modules
+  // fall back to fetching for themselves and report what they can.
+  try {
+    const page = await fetchPage(normalized, fetchOptions);
+    ctx.html = page.body;
+    ctx.headers = Object.fromEntries(page.headers.entries());
+    ctx.finalUrl = page.finalUrl;
+  } catch {
+    // Left unset on purpose
+  }
 
   // Phase 1: robots + redirects (parallel)
   const phase1Results = await runModules(phase1Modules, ctx);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -85,13 +85,18 @@ export async function runAudit(
     crawlLimit: opts.crawl,
   };
 
-  // Phase 0: fetch the page once and share it. When this fails the modules
-  // fall back to fetching for themselves and report what they can.
+  // Phase 0: fetch the page once and share it. A failed or non-2xx fetch is
+  // not shared and is dropped from the cache, so the modules try again for
+  // themselves and report what they can.
   try {
     const page = await fetchPage(normalized, fetchOptions);
-    ctx.html = page.body;
-    ctx.headers = Object.fromEntries(page.headers.entries());
-    ctx.finalUrl = page.finalUrl;
+    if (page.status >= 200 && page.status < 300) {
+      ctx.html = page.body;
+      ctx.headers = Object.fromEntries(page.headers.entries());
+      ctx.finalUrl = page.finalUrl;
+    } else {
+      fetchOptions.cache?.clear();
+    }
   } catch {
     // Left unset on purpose
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,9 +167,14 @@ export interface RedirectChain {
   isCircular: boolean;
 }
 
+// In-flight and settled responses keyed by method and URL, shared by every
+// module of one audit so the same URL is never requested twice.
+export type FetchCache = Map<string, Promise<unknown>>;
+
 export interface FetchOptions {
   timeout?: number;
   userAgent?: string;
+  cache?: FetchCache;
 }
 
 export interface AuditContext {
@@ -180,6 +185,7 @@ export interface AuditContext {
   robotsTxt?: string;
   html?: string;
   headers?: Record<string, string>;
+  finalUrl?: string;
   pages?: string[];
   sitemapUrls?: string[];
   crawlLimit?: number;

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import type { FetchCache } from '../types.js';
 import { fetchPage, fetchHead, fetchWithoutRedirect, followRedirectChain } from './http.js';
 
@@ -45,19 +47,33 @@ describe('fetchPage', () => {
     expect(requestedUrls()).toEqual(['https://example.com/', 'https://example.com/landing']);
   });
 
-  it('falls back to a follow GET when the last hop body was already consumed', async () => {
+  it('reuses the page read through another URL that redirected to it', async () => {
     const cache: FetchCache = new Map();
     mockFetch
       .mockResolvedValueOnce(response(302, '', { location: '/b' }))
-      .mockResolvedValueOnce(response(200, '<html>b</html>'))
-      .mockResolvedValueOnce(response(200, '<html>b again</html>'));
+      .mockResolvedValueOnce(response(200, '<html>b</html>'));
 
     await fetchPage('https://example.com/a', { cache });
-    const again = await fetchPage('https://example.com/b', { cache });
+    const direct = await fetchPage('https://example.com/b', { cache });
 
-    expect(again.body).toBe('<html>b again</html>');
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    expect(mockFetch.mock.calls[2][1]).toMatchObject({ redirect: 'follow' });
+    expect(direct.body).toBe('<html>b</html>');
+    expect(direct.finalUrl).toBe('https://example.com/b');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to a follow GET when something else consumed the cached response', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch
+      .mockResolvedValueOnce(response(200, '<html>first</html>'))
+      .mockResolvedValueOnce(response(200, '<html>again</html>'));
+
+    const raw = await fetchWithoutRedirect('https://example.com/', { cache });
+    await raw.text();
+    const page = await fetchPage('https://example.com/', { cache });
+
+    expect(page.body).toBe('<html>again</html>');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({ redirect: 'follow' });
   });
 
   it('gives up on a body that never finishes', async () => {
@@ -65,6 +81,59 @@ describe('fetchPage', () => {
     mockFetch.mockResolvedValueOnce(stalled);
 
     await expect(fetchPage('https://example.com/', { timeout: 20 })).rejects.toThrow(/Timed out/);
+  });
+
+  it('reads one body for redirect chains that converge on the same page', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/tgt')) return response(200, '<html>tgt</html>');
+      return response(302, '', { location: '/tgt' });
+    });
+
+    const pages = await Promise.all(
+      Array.from({ length: 20 }, (_, i) => fetchPage(`https://example.com/s${i}`, { cache })),
+    );
+
+    expect(pages.every((p) => p.body === '<html>tgt</html>')).toBe(true);
+    expect(pages.every((p) => p.finalUrl === 'https://example.com/tgt')).toBe(true);
+    expect(requestedUrls().filter((u) => u.endsWith('/tgt'))).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(21);
+  });
+});
+
+describe('fetchPage against a real socket', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('closes the connection when the body times out', async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html', 'content-length': 1000 });
+      res.write('<html>');
+      // Never ends.
+    });
+    const closed = new Promise<void>((resolve) => {
+      server.once('connection', (socket) => socket.once('close', () => resolve()));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(
+        fetchPage(`http://127.0.0.1:${port}/stall`, { timeout: 100 }),
+      ).rejects.toThrow(/Timed out reading body/);
+
+      await Promise.race([
+        closed,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('socket still open 500ms after the timeout')), 500),
+        ),
+      ]);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FetchCache } from '../types.js';
+import { fetchPage, fetchHead, fetchWithoutRedirect, followRedirectChain } from './http.js';
+
+const mockFetch = vi.fn<typeof fetch>();
+
+function response(status: number, body = '', headers: Record<string, string> = {}): Response {
+  return new Response(body, { status, headers });
+}
+
+function requestedUrls(): string[] {
+  return mockFetch.mock.calls.map(([input]) => String(input));
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchPage', () => {
+  it('returns the body of a direct 200 with a single request', async () => {
+    mockFetch.mockResolvedValueOnce(response(200, '<html>ok</html>', { 'x-test': '1' }));
+
+    const page = await fetchPage('https://example.com/');
+
+    expect(page).toMatchObject({ body: '<html>ok</html>', status: 200, finalUrl: 'https://example.com/' });
+    expect(page.headers.get('x-test')).toBe('1');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('walks a redirect chain and reads the last hop without a second GET', async () => {
+    mockFetch
+      .mockResolvedValueOnce(response(301, '', { location: '/landing' }))
+      .mockResolvedValueOnce(response(200, '<html>landing</html>'));
+
+    const page = await fetchPage('https://example.com/');
+
+    expect(page.body).toBe('<html>landing</html>');
+    expect(page.finalUrl).toBe('https://example.com/landing');
+    expect(requestedUrls()).toEqual(['https://example.com/', 'https://example.com/landing']);
+  });
+
+  it('falls back to a follow GET when the last hop body was already consumed', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch
+      .mockResolvedValueOnce(response(302, '', { location: '/b' }))
+      .mockResolvedValueOnce(response(200, '<html>b</html>'))
+      .mockResolvedValueOnce(response(200, '<html>b again</html>'));
+
+    await fetchPage('https://example.com/a', { cache });
+    const again = await fetchPage('https://example.com/b', { cache });
+
+    expect(again.body).toBe('<html>b again</html>');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls[2][1]).toMatchObject({ redirect: 'follow' });
+  });
+
+  it('gives up on a body that never finishes', async () => {
+    const stalled = new Response(new ReadableStream({ start() {} }), { status: 200 });
+    mockFetch.mockResolvedValueOnce(stalled);
+
+    await expect(fetchPage('https://example.com/', { timeout: 20 })).rejects.toThrow(/Timed out/);
+  });
+});
+
+describe('per-audit cache', () => {
+  it('serves repeated fetchPage calls from one request', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch.mockResolvedValue(response(200, '<html>ok</html>'));
+
+    const first = await fetchPage('https://example.com/', { cache });
+    const second = await fetchPage('https://example.com/', { cache });
+
+    expect(second).toBe(first);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one manual request between followRedirectChain and fetchPage', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch.mockResolvedValue(response(200, '<xml/>'));
+
+    const chain = await followRedirectChain('https://example.com/sitemap.xml', { cache });
+    const page = await fetchPage('https://example.com/sitemap.xml', { cache });
+
+    expect(chain.hops).toEqual([]);
+    expect(page.body).toBe('<xml/>');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes fetchHead and fetchWithoutRedirect but keeps methods apart', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch.mockImplementation(async () => response(200));
+
+    await fetchHead('https://example.com/a.png', { cache });
+    await fetchHead('https://example.com/a.png', { cache });
+    await fetchWithoutRedirect('https://example.com/a.png', { cache });
+    await fetchWithoutRedirect('https://example.com/a.png', { cache });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({ method: 'HEAD' });
+    expect(mockFetch.mock.calls[1][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('joins concurrent callers onto the same in-flight request', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch.mockImplementation(async () => response(200));
+
+    await Promise.all([
+      fetchHead('https://example.com/', { cache }),
+      fetchHead('https://example.com/', { cache }),
+      fetchHead('https://example.com/', { cache }),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets a failed request so the next caller retries', async () => {
+    const cache: FetchCache = new Map();
+    mockFetch
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(response(200));
+
+    await expect(fetchHead('https://example.com/', { cache })).rejects.toThrow('ECONNRESET');
+    const second = await fetchHead('https://example.com/', { cache });
+
+    expect(second.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(1);
+  });
+
+  it('does nothing without a cache', async () => {
+    mockFetch.mockImplementation(async () => response(200));
+
+    await fetchHead('https://example.com/');
+    await fetchHead('https://example.com/');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -28,6 +28,10 @@ function cached<T>(
   return pending;
 }
 
+// The controller behind each hop response, kept so a body read that times out
+// can tear the connection down after the header timer has already been cleared.
+const hopControllers = new WeakMap<Response, AbortController>();
+
 export function fetchWithoutRedirect(
   url: string,
   opts?: FetchOptions,
@@ -38,11 +42,13 @@ export function fetchWithoutRedirect(
     const timer = setTimeout(() => controller.abort(), timeout);
 
     try {
-      return await fetch(url, {
+      const res = await fetch(url, {
         redirect: 'manual',
         signal: controller.signal,
         headers: buildHeaders(opts?.userAgent),
       });
+      hopControllers.set(res, controller);
+      return res;
     } finally {
       clearTimeout(timer);
     }
@@ -95,19 +101,54 @@ export async function followRedirectChain(
   return chain;
 }
 
-// The hop responses come back with the abort timer already cleared, so reading
-// the body gets its own deadline.
+// The hop responses come back with the abort timer already cleared, so the
+// body is read through a reader with its own deadline. On timeout the hop's
+// controller is aborted and the reader cancelled, which closes the socket;
+// `res.text()` would have locked the stream and left it open.
 async function readBody(res: Response, timeout: number): Promise<string> {
+  if (!res.body) return '';
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
   let timer: NodeJS.Timeout | undefined;
   const expired = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error(`Timed out reading body of ${res.url}`)), timeout);
   });
 
   try {
-    return await Promise.race([res.text(), expired]);
+    for (;;) {
+      const { done, value } = await Promise.race([reader.read(), expired]);
+      if (done) break;
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join('');
   } catch (err) {
-    await res.body?.cancel().catch(() => undefined);
+    hopControllers.get(res)?.abort();
+    await reader.cancel().catch(() => undefined);
     throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+type PageResult = { body: string; status: number; headers: Headers };
+
+async function fetchFollowing(url: string, opts?: FetchOptions): Promise<PageResult> {
+  const controller = new AbortController();
+  const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: buildHeaders(opts?.userAgent),
+    });
+
+    const body = await res.text();
+    return { body, status: res.status, headers: res.headers };
   } finally {
     clearTimeout(timer);
   }
@@ -122,29 +163,19 @@ export function fetchPage(
     const { chain, response } = await walkRedirects(url, opts);
     const finalUrl = chain.finalUrl;
 
-    // The last hop already carries the page; a body that some other caller has
-    // consumed, or a walk that never produced a response, falls through to a
-    // plain GET.
-    if (response && !response.bodyUsed) {
-      const body = await readBody(response, timeout);
-      return { body, status: response.status, headers: response.headers, finalUrl };
-    }
+    // The last hop already carries the page. Its text is cached under the
+    // final URL so chains that converge on one page share a single read; a
+    // body some other caller has consumed, or a walk that never produced a
+    // response, falls through to a plain GET.
+    const page = await cached(opts, `PAGE ${finalUrl}`, async () => {
+      if (response && !response.bodyUsed) {
+        const body = await readBody(response, timeout);
+        return { body, status: response.status, headers: response.headers };
+      }
+      return fetchFollowing(finalUrl, opts);
+    });
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeout);
-
-    try {
-      const res = await fetch(finalUrl, {
-        redirect: 'follow',
-        signal: controller.signal,
-        headers: buildHeaders(opts?.userAgent),
-      });
-
-      const body = await res.text();
-      return { body, status: res.status, headers: res.headers, finalUrl };
-    } finally {
-      clearTimeout(timer);
-    }
+    return { ...page, finalUrl };
   });
 }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -8,36 +8,60 @@ function buildHeaders(userAgent?: string): Record<string, string> {
   };
 }
 
-export async function fetchWithoutRedirect(
+// Runs `load` once per key for the lifetime of the cache in `opts`. Concurrent
+// callers share the pending promise; a rejected request is forgotten so a later
+// caller can try again. Without a cache every call goes to the network.
+function cached<T>(
+  opts: FetchOptions | undefined,
+  key: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  const cache = opts?.cache;
+  if (!cache) return load();
+
+  const hit = cache.get(key) as Promise<T> | undefined;
+  if (hit) return hit;
+
+  const pending = load();
+  cache.set(key, pending);
+  pending.catch(() => cache.delete(key));
+  return pending;
+}
+
+export function fetchWithoutRedirect(
   url: string,
   opts?: FetchOptions,
 ): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
-  const timer = setTimeout(() => controller.abort(), timeout);
+  return cached(opts, `MANUAL ${url}`, async () => {
+    const controller = new AbortController();
+    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
+    const timer = setTimeout(() => controller.abort(), timeout);
 
-  try {
-    return await fetch(url, {
-      redirect: 'manual',
-      signal: controller.signal,
-      headers: buildHeaders(opts?.userAgent),
-    });
-  } finally {
-    clearTimeout(timer);
-  }
+    try {
+      return await fetch(url, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: buildHeaders(opts?.userAgent),
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  });
 }
 
-export async function followRedirectChain(
+// Walks redirects hop by hop. `response` is the first non-redirect response,
+// or undefined when a hop failed or MAX_REDIRECTS ran out.
+async function walkRedirects(
   url: string,
   opts?: FetchOptions,
-): Promise<RedirectChain> {
+): Promise<{ chain: RedirectChain; response?: Response }> {
   const hops: RedirectHop[] = [];
   const seen = new Set<string>();
   let current = url;
 
   for (let i = 0; i < MAX_REDIRECTS; i++) {
     if (seen.has(current)) {
-      return { hops, finalUrl: current, isCircular: true };
+      return { chain: { hops, finalUrl: current, isCircular: true } };
     }
     seen.add(current);
 
@@ -56,55 +80,93 @@ export async function followRedirectChain(
       hops.push({ url: current, status, location: resolved });
       current = resolved;
     } else {
-      return { hops, finalUrl: current, isCircular: false };
+      return { chain: { hops, finalUrl: current, isCircular: false }, response: res };
     }
   }
 
-  return { hops, finalUrl: current, isCircular: false };
+  return { chain: { hops, finalUrl: current, isCircular: false } };
 }
 
-export async function fetchPage(
+export async function followRedirectChain(
+  url: string,
+  opts?: FetchOptions,
+): Promise<RedirectChain> {
+  const { chain } = await walkRedirects(url, opts);
+  return chain;
+}
+
+// The hop responses come back with the abort timer already cleared, so reading
+// the body gets its own deadline.
+async function readBody(res: Response, timeout: number): Promise<string> {
+  let timer: NodeJS.Timeout | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out reading body of ${res.url}`)), timeout);
+  });
+
+  try {
+    return await Promise.race([res.text(), expired]);
+  } catch (err) {
+    await res.body?.cancel().catch(() => undefined);
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function fetchPage(
   url: string,
   opts?: FetchOptions,
 ): Promise<{ body: string; status: number; headers: Headers; finalUrl: string }> {
-  const chain = await followRedirectChain(url, opts);
-  const finalUrl = chain.finalUrl;
+  return cached(opts, `GET ${url}`, async () => {
+    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
+    const { chain, response } = await walkRedirects(url, opts);
+    const finalUrl = chain.finalUrl;
 
-  const controller = new AbortController();
-  const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
-  const timer = setTimeout(() => controller.abort(), timeout);
+    // The last hop already carries the page; a body that some other caller has
+    // consumed, or a walk that never produced a response, falls through to a
+    // plain GET.
+    if (response && !response.bodyUsed) {
+      const body = await readBody(response, timeout);
+      return { body, status: response.status, headers: response.headers, finalUrl };
+    }
 
-  try {
-    const res = await fetch(finalUrl, {
-      redirect: 'follow',
-      signal: controller.signal,
-      headers: buildHeaders(opts?.userAgent),
-    });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
 
-    const body = await res.text();
-    return { body, status: res.status, headers: res.headers, finalUrl };
-  } finally {
-    clearTimeout(timer);
-  }
+    try {
+      const res = await fetch(finalUrl, {
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: buildHeaders(opts?.userAgent),
+      });
+
+      const body = await res.text();
+      return { body, status: res.status, headers: res.headers, finalUrl };
+    } finally {
+      clearTimeout(timer);
+    }
+  });
 }
 
-export async function fetchHead(
+export function fetchHead(
   url: string,
   opts?: FetchOptions,
 ): Promise<{ status: number; headers: Headers }> {
-  const controller = new AbortController();
-  const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
-  const timer = setTimeout(() => controller.abort(), timeout);
+  return cached(opts, `HEAD ${url}`, async () => {
+    const controller = new AbortController();
+    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
+    const timer = setTimeout(() => controller.abort(), timeout);
 
-  try {
-    const res = await fetch(url, {
-      method: 'HEAD',
-      redirect: 'follow',
-      signal: controller.signal,
-      headers: buildHeaders(opts?.userAgent),
-    });
-    return { status: res.status, headers: res.headers };
-  } finally {
-    clearTimeout(timer);
-  }
+    try {
+      const res = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: buildHeaders(opts?.userAgent),
+      });
+      return { status: res.status, headers: res.headers };
+    } finally {
+      clearTimeout(timer);
+    }
+  });
 }


### PR DESCRIPTION
one audit of one url was doing 34 requests, 19 of them GET / because every module fetched the page for itself and fetchPage walked the redirect chain and then fetched again. AuditContext already had html and headers fields for exactly this, the runner just never filled them outside crawl mode.

now the runner fetches once up front (only shared when it's a 2xx, a transient 500 shouldn't become the audit), modules read ctx.html and fall back to fetchPage when it's not there, fetchPage keeps the body of the last hop instead of a second GET, and a per audit cache dedupes GET/HEAD by url. crawl skips the cache since every crawled url is fetched once anyway and holding 5000 bodies for nothing is silly.

34 → 11 requests on the harness, 7 without the common page probes. finding codes come out identical. side effect: APP_ROUTER_METADATA actually fires now, before it depended on which module finished first.

body reads got their own timeout that really aborts the socket, the old cancel() was a no op because text() had already locked the stream.

harness is in src/runner.requests.test.ts so the number stays checked.
