### PR TITLE
docs: bring SECURITY.md up to date

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,20 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.5.x   | Yes       |
-| < 0.5   | No        |
+| 2.x     | Yes       |
+| < 2.0   | No        |
+
+Fixes ship in the next patch release on npm; the Marketplace action's `v1` and `v2` tags follow the
+latest release.
 
 ## Reporting a vulnerability
 
 If you discover a security vulnerability in this project, please report it
 responsibly. **Do not open a public issue.**
 
-Instead, email the maintainer directly (see the `author` field in `package.json`)
-or use [GitHub's private vulnerability reporting](https://github.com/JosephDoUrden/vercel-seo-audit/security/advisories/new).
+Use [GitHub's private vulnerability reporting](https://github.com/JosephDoUrden/vercel-seo-audit/security/advisories/new)
+on this repository (Security tab, "Report a vulnerability"). If that is not an option, email the
+maintainer (see the `author` field in `package.json`).
 
 Please include:
 
@@ -21,5 +25,12 @@ Please include:
 - Steps to reproduce
 - The potential impact
 
-You should receive an acknowledgement within 48 hours. We will work with you to
-understand and address the issue before any public disclosure.
+You should receive an acknowledgement within 48 hours and an initial assessment within 7 days.
+Fixes are released as soon as practical and credited in the release notes unless you prefer
+otherwise. Please give us the chance to ship a fix before any public disclosure.
+
+## Scope notes
+
+- The CLI fetches the URL you give it and the pages it links to. It never executes page JavaScript.
+- The GitHub Action passes its inputs to the CLI as arguments, never through a shell string
+  (fixed in 2.5.1).


### PR DESCRIPTION
supported versions said 0.5.x, the package is on 2.x. private vulnerability reporting is switched on for the repo now so it's the first route. adds the assessment window and two scope notes (no js execution, action inputs never go through a shell).