### PR TITLE
ci: add a gate job for the branch ruleset to require

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,18 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm run test:coverage
+
+  # One stable check name for the branch ruleset to require. Matrix legs rename themselves when the
+  # matrix changes and a skipped leg leaves a PR waiting forever, so the ruleset points at this job
+  # only. It fails unless every build leg succeeded.
+  gate:
+    name: gate
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      BUILD: ${{ needs.build.result }}
+    steps:
+      - run: |
+          echo "build=$BUILD"
+          test "$BUILD" = success


### PR DESCRIPTION
matrix leg names change whenever the matrix does and a skipped leg leaves a PR waiting forever, so the ruleset will require this one job instead. fails unless every build leg succeeded.