### PR TITLE
feat(audit): add header-based Vercel platform checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ already fetched for the other modules and make no requests of their own. Off Ver
 
 * `x-vercel-cache: MISS` or `STALE` on a page the CDN could store (no `set-cookie`,
   no `private` / `no-store` / `no-cache`, no `Vary: *`)
-* No `cache-control` at all, or a `cdn-cache-control` without a lifetime, on a page that missed the cache
+* A page that missed the cache with no CDN lifetime readable from its headers: no `s-maxage`
+  in `cache-control` (Vercel's default `public, max-age=0, must-revalidate` is the usual case),
+  or no `s-maxage` / `max-age` in `cdn-cache-control` when that header is present. `s-maxage=0`
+  counts as a lifetime, so a deliberate opt-out is not reported
 * CDN lifetime below 60 seconds, and a lifetime without `stale-while-revalidate`. These read
   `s-maxage` from `cache-control`, or `s-maxage` / `max-age` from `cdn-cache-control` when that
   header is present (it overrides `cache-control` entirely). Vercel normally consumes `s-maxage`

--- a/README.md
+++ b/README.md
@@ -248,9 +248,11 @@ already fetched for the other modules and make no requests of their own. Off Ver
 * `x-vercel-cache: MISS` or `STALE` on a page the CDN could store (no `set-cookie`,
   no `private` / `no-store` / `no-cache`, no `Vary: *`)
 * No `cache-control` at all, or a `cdn-cache-control` without a lifetime, on a page that missed the cache
-* CDN lifetime below 60 seconds, and a lifetime without `stale-while-revalidate`. Vercel
-  consumes `s-maxage` and `stale-while-revalidate` before the client sees them, so these
-  two only fire when the directives are visible, which in practice means `CDN-Cache-Control` is set
+* CDN lifetime below 60 seconds, and a lifetime without `stale-while-revalidate`. These read
+  `s-maxage` from `cache-control`, or `s-maxage` / `max-age` from `cdn-cache-control` when that
+  header is present (it overrides `cache-control` entirely). Vercel normally consumes `s-maxage`
+  before the client sees it, so a lifetime is only readable when it comes through. `s-maxage=0`
+  is treated as deliberately uncached
 * A `*.vercel.app` URL without `x-robots-tag: noindex` or a robots meta `noindex`. Branch
   URLs (`<project>-git-<branch>-<scope>.vercel.app`) are always previews and get an
   error; other generated URLs can be the production deployment itself and get a warning

--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ Progress is printed to stderr as each page is crawled.
 * Detect Next.js trailing slash redirect behaviour
 * Middleware rewrite/redirect headers (best-effort)
 
+### Vercel platform
+
+Header-based checks that only make sense on Vercel's CDN. They read the page response
+already fetched for the other modules and make no requests of their own. Off Vercel
+(no `server: Vercel` and no `x-vercel-id`) the module reports that once and stops.
+
+* `x-vercel-cache: MISS` or `STALE` on a page the CDN could store (no `set-cookie`,
+  no `private` / `no-store` / `no-cache`, no `Vary: *`)
+* No `cache-control` at all, or a `cdn-cache-control` without a lifetime, on a page that missed the cache
+* CDN lifetime below 60 seconds, and a lifetime without `stale-while-revalidate`. Vercel
+  consumes `s-maxage` and `stale-while-revalidate` before the client sees them, so these
+  two only fire when the directives are visible, which in practice means `CDN-Cache-Control` is set
+* A `*.vercel.app` URL without `x-robots-tag: noindex` or a robots meta `noindex`. Branch
+  URLs (`<project>-git-<branch>-<scope>.vercel.app`) are always previews and get an
+  error; other generated URLs can be the production deployment itself and get a warning
+
 ---
 
 ## Severity & exit codes
@@ -370,6 +386,22 @@ npx vercel-seo-audit https://your-site.com --report md
 * [ ] Accessibility basics audit ([#45](https://github.com/JosephDoUrden/vercel-seo-audit/issues/45))
 * [ ] Multi-URL batch auditing ([#46](https://github.com/JosephDoUrden/vercel-seo-audit/issues/46))
 * [ ] Plugin system for custom audit checks ([#47](https://github.com/JosephDoUrden/vercel-seo-audit/issues/47))
+
+---
+
+## What this does not do
+
+* **No JavaScript execution.** Pages are fetched and parsed as HTML. Anything rendered on the
+  client, including metadata injected by scripts, is invisible to the audit.
+* **No source reading.** It never opens `app/**`, `pages/**`, `next.config.js` or `vercel.json`;
+  it only sees what the deployed site sends back.
+* **No field Core Web Vitals.** The performance hints are static heuristics on the HTML. Real
+  user metrics need PageSpeed Insights or a RUM tool.
+* **No schema.org validation.** JSON-LD is checked for well-formedness and a few required
+  fields, not against the schema.org vocabulary.
+* **Vercel checks are header-based only.** They cannot see `s-maxage` the CDN has already
+  consumed, cannot tell a cold miss from an uncached page on one request, and cannot reach a
+  deployment behind Deployment Protection.
 
 ---
 

--- a/src/audit/crawl.test.ts
+++ b/src/audit/crawl.test.ts
@@ -138,6 +138,14 @@ describe('auditCrawl', () => {
     expect(noindex[0].severity).toBe('warning');
   });
 
+  it('detects noindex via an upper-case meta name="ROBOTS"', async () => {
+    const html = '<html><head><meta name="ROBOTS" content="noindex"><title>T</title><meta name="description" content="D"><link rel="canonical" href="https://example.com/p"><script type="application/ld+json">{}</script></head><body></body></html>';
+    mockFetchPage.mockResolvedValue(makePage(html));
+    const ctx = makeCtx({ sitemapUrls: ['https://example.com/p'] });
+    const findings = await auditCrawl(ctx);
+    expect(findings.some((f) => f.code === 'CRAWL_PAGE_NOINDEX')).toBe(true);
+  });
+
   it('detects noindex via meta name="googlebot"', async () => {
     const html = '<html><head><meta name="googlebot" content="noindex"><title>T</title><meta name="description" content="D"><link rel="canonical" href="https://example.com/p"><script type="application/ld+json">{}</script></head><body></body></html>';
     mockFetchPage.mockResolvedValue(makePage(html));

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -10,3 +10,4 @@ export { auditI18n } from './i18n.js';
 export { auditImages } from './images.js';
 export { auditSecurity } from './security.js';
 export { auditPerformance } from './performance.js';
+export { auditVercel } from './vercel.js';

--- a/src/audit/metadata.test.ts
+++ b/src/audit/metadata.test.ts
@@ -74,6 +74,14 @@ describe('auditMetadata', () => {
     expect(noindex!.severity).toBe('error');
   });
 
+  it('detects NOINDEX_DETECTED when the meta name is upper-case', async () => {
+    mockFetchPage.mockResolvedValue(
+      makePage('<html><head><meta name="ROBOTS" content="NOINDEX"></head><body></body></html>'),
+    );
+    const findings = await auditMetadata(makeCtx());
+    expect(findings.find((f) => f.code === 'NOINDEX_DETECTED')).toBeDefined();
+  });
+
   it('detects X_ROBOTS_NOINDEX header', async () => {
     const headers = new Headers({ 'x-robots-tag': 'noindex' });
     mockFetchPage.mockResolvedValue(makePage(FULL_HTML, { headers }));

--- a/src/audit/metadata.test.ts
+++ b/src/audit/metadata.test.ts
@@ -82,6 +82,14 @@ describe('auditMetadata', () => {
     expect(findings.find((f) => f.code === 'NOINDEX_DETECTED')).toBeDefined();
   });
 
+  it('detects NOINDEX_DETECTED for a robots meta of none', async () => {
+    mockFetchPage.mockResolvedValue(
+      makePage('<html><head><meta name="robots" content="none"></head><body></body></html>'),
+    );
+    const findings = await auditMetadata(makeCtx());
+    expect(findings.find((f) => f.code === 'NOINDEX_DETECTED')).toBeDefined();
+  });
+
   it('detects X_ROBOTS_NOINDEX header', async () => {
     const headers = new Headers({ 'x-robots-tag': 'noindex' });
     mockFetchPage.mockResolvedValue(makePage(FULL_HTML, { headers }));

--- a/src/audit/vercel.test.ts
+++ b/src/audit/vercel.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+import type { AuditContext } from '../types.js';
+import { auditVercel } from './vercel.js';
+
+function makeCtx(overrides: Partial<AuditContext> = {}): AuditContext {
+  return {
+    url: 'https://example.com',
+    normalizedUrl: 'https://example.com/',
+    fetchOptions: {},
+    verbose: false,
+    ...overrides,
+  };
+}
+
+// What a cached page on a custom domain looks like from the client side:
+// Vercel has consumed s-maxage and sends its default cache-control back.
+const VERCEL_HIT: Record<string, string> = {
+  server: 'Vercel',
+  'x-vercel-id': 'lhr1::abc12-1700000000000-0123456789ab',
+  'x-vercel-cache': 'HIT',
+  'cache-control': 'public, max-age=0, must-revalidate',
+};
+
+const codes = (findings: { code: string }[]) => findings.map((f) => f.code);
+
+describe('auditVercel', () => {
+  describe('detection', () => {
+    it('returns no findings when phase 0 did not produce headers', async () => {
+      const findings = await auditVercel(makeCtx({ headers: undefined }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('reports NOT_ON_VERCEL once and nothing else when no Vercel signal is present', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: { server: 'nginx', 'x-vercel-cache': 'MISS', 'cache-control': 'public' } }),
+      );
+      expect(codes(findings)).toEqual(['NOT_ON_VERCEL']);
+      expect(findings[0].severity).toBe('info');
+      expect(findings[0].category).toBe('vercel');
+    });
+
+    it('treats x-vercel-id alone as a Vercel signal', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: { 'x-vercel-id': 'fra1::x', 'x-vercel-cache': 'MISS', 'cache-control': 'public, max-age=0' } }),
+      );
+      expect(codes(findings)).not.toContain('NOT_ON_VERCEL');
+      expect(codes(findings)).toContain('VERCEL_CACHE_MISS');
+    });
+
+    it('matches the server header case-insensitively', async () => {
+      const findings = await auditVercel(makeCtx({ headers: { server: 'vercel', 'x-vercel-cache': 'STALE' } }));
+      expect(codes(findings)).toEqual(['VERCEL_CACHE_STALE']);
+    });
+
+    it('is quiet on a cached page served from a custom domain', async () => {
+      const findings = await auditVercel(makeCtx({ headers: VERCEL_HIT }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('tags every finding with the vercel category and the audited url', async () => {
+      const findings = await auditVercel(
+        makeCtx({
+          headers: { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 's-maxage=10' },
+          finalUrl: 'https://app-git-feature-team.vercel.app/',
+        }),
+      );
+      expect(findings.length).toBeGreaterThan(2);
+      for (const f of findings) {
+        expect(f.category).toBe('vercel');
+        expect(f.url).toBe('https://app-git-feature-team.vercel.app/');
+      }
+    });
+  });
+
+  describe('x-vercel-cache', () => {
+    it('reports VERCEL_CACHE_MISS as info with the header values in details', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      const miss = findings.find((f) => f.code === 'VERCEL_CACHE_MISS');
+      expect(miss).toBeDefined();
+      expect(miss!.severity).toBe('info');
+      expect(miss!.details).toMatchObject({
+        xVercelCache: 'MISS',
+        cacheControl: 'public, max-age=0, must-revalidate',
+      });
+    });
+
+    it('reads the cache status case-insensitively', async () => {
+      const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': 'miss' } }));
+      expect(codes(findings)).toContain('VERCEL_CACHE_MISS');
+    });
+
+    it('reports VERCEL_CACHE_STALE as info', async () => {
+      const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': 'STALE' } }));
+      const stale = findings.find((f) => f.code === 'VERCEL_CACHE_STALE');
+      expect(stale).toBeDefined();
+      expect(stale!.severity).toBe('info');
+      expect(stale!.details).toMatchObject({ xVercelCache: 'STALE' });
+    });
+
+    it.each(['HIT', 'PRERENDER', 'REVALIDATED', 'BYPASS'])('says nothing about a %s', async (status) => {
+      const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': status } }));
+      expect(codes(findings)).not.toContain('VERCEL_CACHE_MISS');
+      expect(codes(findings)).not.toContain('VERCEL_CACHE_STALE');
+      expect(codes(findings)).not.toContain('VERCEL_CACHE_CONTROL_MISSING');
+    });
+
+    it('does not report a miss when the response sets a cookie', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'set-cookie': 'session=abc; Path=/' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it.each(['private, max-age=0', 'no-store', 'no-cache, max-age=0', 'Private, No-Store'])(
+      'does not report a miss when cache-control is "%s"',
+      async (cc) => {
+        const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cache-control': cc };
+        const findings = await auditVercel(makeCtx({ headers }));
+        expect(findings).toHaveLength(0);
+      },
+    );
+
+    it('does not report a miss when Vary is *', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', vary: '*' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('does not report a miss when cdn-cache-control opts out', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'no-store' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  describe('cache-control directives', () => {
+    it('warns when the page missed the cache and sends no cache-control at all', async () => {
+      const { 'cache-control': _, ...rest } = VERCEL_HIT;
+      const findings = await auditVercel(makeCtx({ headers: { ...rest, 'x-vercel-cache': 'MISS' } }));
+      const f = findings.find((x) => x.code === 'VERCEL_CACHE_CONTROL_MISSING');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('warning');
+    });
+
+    it('warns when cdn-cache-control is visible but carries no lifetime', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'public' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toContain('VERCEL_CACHE_CONTROL_MISSING');
+    });
+
+    it('does not warn on the ambiguous default cache-control after a miss', async () => {
+      // Vercel strips s-maxage before the client sees it, so this could be a cold miss.
+      const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': 'MISS' } }));
+      expect(codes(findings)).toEqual(['VERCEL_CACHE_MISS']);
+    });
+
+    it('does not warn when a lifetime is visible', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'max-age=86400, stale-while-revalidate=60' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toEqual(['VERCEL_CACHE_MISS']);
+    });
+
+    it('does not warn about missing cache-control on a HIT', async () => {
+      const { 'cache-control': _, ...rest } = VERCEL_HIT;
+      const findings = await auditVercel(makeCtx({ headers: rest }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('reports a short s-maxage from cdn-cache-control', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=1, stale-while-revalidate=59' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      const f = findings.find((x) => x.code === 'VERCEL_S_MAXAGE_SHORT');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('info');
+      expect(f!.details).toMatchObject({ sMaxage: 1, floor: 60 });
+      expect(codes(findings)).not.toContain('VERCEL_SWR_MISSING');
+    });
+
+    it('takes max-age from cdn-cache-control when s-maxage is absent', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 'max-age=30' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toContain('VERCEL_S_MAXAGE_SHORT');
+      expect(codes(findings)).toContain('VERCEL_SWR_MISSING');
+    });
+
+    it('reports a short s-maxage when cache-control reaches the client with it', async () => {
+      const headers = { ...VERCEL_HIT, 'cache-control': 'public, s-maxage=10' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toContain('VERCEL_S_MAXAGE_SHORT');
+    });
+
+    it('ignores s-maxage in cache-control when cdn-cache-control overrides it', async () => {
+      const headers = { ...VERCEL_HIT, 'cache-control': 'public, s-maxage=10', 'cdn-cache-control': 'public' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).not.toContain('VERCEL_S_MAXAGE_SHORT');
+    });
+
+    it('prefers cdn-cache-control over cache-control for the lifetime', async () => {
+      const headers = { ...VERCEL_HIT, 'cache-control': 's-maxage=10', 'cdn-cache-control': 's-maxage=3600, stale-while-revalidate=60' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('accepts an s-maxage at the floor', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=60, stale-while-revalidate=600' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('reports a missing stale-while-revalidate when a lifetime is visible', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=86400' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      const f = findings.find((x) => x.code === 'VERCEL_SWR_MISSING');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('info');
+      expect(codes(findings)).not.toContain('VERCEL_S_MAXAGE_SHORT');
+    });
+
+    it('says nothing about lifetimes when no directive is visible', async () => {
+      const findings = await auditVercel(makeCtx({ headers: VERCEL_HIT }));
+      expect(findings).toHaveLength(0);
+    });
+
+    it('ignores a non-numeric s-maxage', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=abc' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).not.toContain('VERCEL_S_MAXAGE_SHORT');
+    });
+  });
+
+  describe('preview deployments', () => {
+    const noindexHtml = '<html><head><meta name="robots" content="noindex, nofollow"></head></html>';
+
+    it('errors on an indexable branch preview url', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://my-app-git-feature-x-acme.vercel.app/' }),
+      );
+      const f = findings.find((x) => x.code === 'VERCEL_PREVIEW_INDEXABLE');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('error');
+      expect(f!.details).toMatchObject({ host: 'my-app-git-feature-x-acme.vercel.app' });
+    });
+
+    it('warns on any other indexable vercel.app host', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://my-app-abc123def-acme.vercel.app/' }),
+      );
+      const f = findings.find((x) => x.code === 'VERCEL_PREVIEW_INDEXABLE');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('warning');
+    });
+
+    it('is satisfied by the x-robots-tag noindex header', async () => {
+      const findings = await auditVercel(
+        makeCtx({
+          headers: { ...VERCEL_HIT, 'x-robots-tag': 'noindex' },
+          finalUrl: 'https://my-app-git-feature-acme.vercel.app/',
+        }),
+      );
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('is satisfied by a robots meta noindex in the html', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, html: noindexHtml, finalUrl: 'https://my-app-git-feature-acme.vercel.app/' }),
+      );
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('ignores custom domains', async () => {
+      const findings = await auditVercel(makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://www.example.com/' }));
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('does not match a look-alike domain', async () => {
+      const findings = await auditVercel(makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://notvercel.app/' }));
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('falls back to the normalised url when there is no final url', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, normalizedUrl: 'https://my-app-git-main-acme.vercel.app/', finalUrl: undefined }),
+      );
+      expect(codes(findings)).toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+  });
+});

--- a/src/audit/vercel.test.ts
+++ b/src/audit/vercel.test.ts
@@ -148,13 +148,28 @@ describe('auditVercel', () => {
       expect(codes(findings)).toContain('VERCEL_CACHE_CONTROL_MISSING');
     });
 
-    it('does not warn on the ambiguous default cache-control after a miss', async () => {
-      // Vercel strips s-maxage before the client sees it, so this could be a cold miss.
+    it('warns on the default cache-control after a miss, naming the lifetime not the header', async () => {
       const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': 'MISS' } }));
+      const f = findings.find((x) => x.code === 'VERCEL_CACHE_CONTROL_MISSING');
+      expect(f).toBeDefined();
+      expect(f!.message).toMatch(/no CDN lifetime/i);
+      expect(f!.message).not.toMatch(/no cache-control header/i);
+    });
+
+    it('warns on an empty cache-control after a miss', async () => {
+      const findings = await auditVercel(makeCtx({ headers: { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cache-control': '' } }));
+      expect(codes(findings)).toContain('VERCEL_CACHE_CONTROL_MISSING');
+    });
+
+    it('does not warn about a missing header when cdn-cache-control carries the lifetime', async () => {
+      const { 'cache-control': _, ...rest } = VERCEL_HIT;
+      const findings = await auditVercel(
+        makeCtx({ headers: { ...rest, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'max-age=600, stale-while-revalidate=60' } }),
+      );
       expect(codes(findings)).toEqual(['VERCEL_CACHE_MISS']);
     });
 
-    it('does not warn when a lifetime is visible', async () => {
+    it('does not warn when a lifetime is visible in cdn-cache-control', async () => {
       const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'max-age=86400, stale-while-revalidate=60' };
       const findings = await auditVercel(makeCtx({ headers }));
       expect(codes(findings)).toEqual(['VERCEL_CACHE_MISS']);
@@ -172,15 +187,24 @@ describe('auditVercel', () => {
       const f = findings.find((x) => x.code === 'VERCEL_S_MAXAGE_SHORT');
       expect(f).toBeDefined();
       expect(f!.severity).toBe('info');
-      expect(f!.details).toMatchObject({ sMaxage: 1, floor: 60 });
+      expect(f!.details).toMatchObject({ lifetime: 1, directive: 's-maxage', source: 'cdn-cache-control', floor: 60 });
       expect(codes(findings)).not.toContain('VERCEL_SWR_MISSING');
     });
 
-    it('takes max-age from cdn-cache-control when s-maxage is absent', async () => {
+    it('takes max-age from cdn-cache-control when s-maxage is absent and says so in details', async () => {
       const headers = { ...VERCEL_HIT, 'cdn-cache-control': 'max-age=30' };
       const findings = await auditVercel(makeCtx({ headers }));
-      expect(codes(findings)).toContain('VERCEL_S_MAXAGE_SHORT');
-      expect(codes(findings)).toContain('VERCEL_SWR_MISSING');
+      const short = findings.find((x) => x.code === 'VERCEL_S_MAXAGE_SHORT');
+      expect(short!.details).toMatchObject({ lifetime: 30, directive: 'max-age', source: 'cdn-cache-control' });
+      const swr = findings.find((x) => x.code === 'VERCEL_SWR_MISSING');
+      expect(swr!.details).toMatchObject({ lifetime: 30, directive: 'max-age', source: 'cdn-cache-control' });
+    });
+
+    it('names cache-control as the source when the lifetime came from it', async () => {
+      const headers = { ...VERCEL_HIT, 'cache-control': 'public, s-maxage=30' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      const short = findings.find((x) => x.code === 'VERCEL_S_MAXAGE_SHORT');
+      expect(short!.details).toMatchObject({ lifetime: 30, directive: 's-maxage', source: 'cache-control' });
     });
 
     it('reports a short s-maxage when cache-control reaches the client with it', async () => {
@@ -221,6 +245,32 @@ describe('auditVercel', () => {
       expect(findings).toHaveLength(0);
     });
 
+    it('ignores stale-while-revalidate in cache-control when cdn-cache-control is present', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=30', 'cache-control': 'public, stale-while-revalidate=600' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toContain('VERCEL_SWR_MISSING');
+    });
+
+    it('treats s-maxage=0 as deliberately uncached', async () => {
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 's-maxage=0' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toEqual(['VERCEL_CACHE_MISS']);
+    });
+
+    it('counts a bare stale-while-revalidate as present', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=3600, stale-while-revalidate' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).not.toContain('VERCEL_SWR_MISSING');
+    });
+
+    it('parses whitespace around the equals sign', async () => {
+      const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage = 10 , stale-while-revalidate = 59' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      const short = findings.find((x) => x.code === 'VERCEL_S_MAXAGE_SHORT');
+      expect(short!.details).toMatchObject({ lifetime: 10 });
+      expect(codes(findings)).not.toContain('VERCEL_SWR_MISSING');
+    });
+
     it('ignores a non-numeric s-maxage', async () => {
       const headers = { ...VERCEL_HIT, 'cdn-cache-control': 's-maxage=abc' };
       const findings = await auditVercel(makeCtx({ headers }));
@@ -259,6 +309,56 @@ describe('auditVercel', () => {
       );
       expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
     });
+
+    it('treats x-robots-tag: none as noindex', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: { ...VERCEL_HIT, 'x-robots-tag': 'none' }, finalUrl: 'https://my-app-git-feature-acme.vercel.app/' }),
+      );
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('does not treat nonexistent directive text as noindex', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: { ...VERCEL_HIT, 'x-robots-tag': 'nonexistent' }, finalUrl: 'https://my-app-git-feature-acme.vercel.app/' }),
+      );
+      expect(codes(findings)).toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('is satisfied by an upper-case robots meta noindex', async () => {
+      const findings = await auditVercel(
+        makeCtx({
+          headers: VERCEL_HIT,
+          html: '<html><head><meta name="ROBOTS" content="NOINDEX"></head></html>',
+          finalUrl: 'https://my-app-git-feature-acme.vercel.app/',
+        }),
+      );
+      expect(codes(findings)).not.toContain('VERCEL_PREVIEW_INDEXABLE');
+    });
+
+    it('does not read a commit url of a project named with git as a branch preview', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://my-git-tools-a1b2c3d4e-acme.vercel.app/' }),
+      );
+      const f = findings.find((x) => x.code === 'VERCEL_PREVIEW_INDEXABLE');
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe('warning');
+    });
+
+    it('still reads a branch named with nine plain letters as a preview', async () => {
+      const findings = await auditVercel(
+        makeCtx({ headers: VERCEL_HIT, finalUrl: 'https://app-git-mybranchx-acme.vercel.app/' }),
+      );
+      expect(findings.find((x) => x.code === 'VERCEL_PREVIEW_INDEXABLE')!.severity).toBe('error');
+    });
+
+    it.each(['git-feature-acme.vercel.app', 'app-git-acme.vercel.app', 'app-git-.vercel.app'])(
+      'does not read %s as a branch preview',
+      async (host) => {
+        const findings = await auditVercel(makeCtx({ headers: VERCEL_HIT, finalUrl: `https://${host}/` }));
+        const f = findings.find((x) => x.code === 'VERCEL_PREVIEW_INDEXABLE');
+        expect(f!.severity).toBe('warning');
+      },
+    );
 
     it('is satisfied by a robots meta noindex in the html', async () => {
       const findings = await auditVercel(

--- a/src/audit/vercel.test.ts
+++ b/src/audit/vercel.test.ts
@@ -126,6 +126,21 @@ describe('auditVercel', () => {
       expect(findings).toHaveLength(0);
     });
 
+    it('judges storability from cdn-cache-control alone when it is present', async () => {
+      // Browser told not to store, CDN told to cache: a documented Vercel pattern.
+      const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cache-control': 'no-store', 'cdn-cache-control': 's-maxage=30' };
+      const findings = await auditVercel(makeCtx({ headers }));
+      expect(codes(findings)).toContain('VERCEL_CACHE_MISS');
+      expect(codes(findings)).toContain('VERCEL_S_MAXAGE_SHORT');
+      expect(codes(findings)).not.toContain('VERCEL_CACHE_CONTROL_MISSING');
+    });
+
+    it('still honours set-cookie and Vary: * when cdn-cache-control is present', async () => {
+      const base = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 's-maxage=30' };
+      expect(await auditVercel(makeCtx({ headers: { ...base, 'set-cookie': 'a=b' } }))).toHaveLength(0);
+      expect(await auditVercel(makeCtx({ headers: { ...base, vary: '*' } }))).toHaveLength(0);
+    });
+
     it('does not report a miss when cdn-cache-control opts out', async () => {
       const headers = { ...VERCEL_HIT, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'no-store' };
       const findings = await auditVercel(makeCtx({ headers }));
@@ -154,6 +169,14 @@ describe('auditVercel', () => {
       expect(f).toBeDefined();
       expect(f!.message).toMatch(/no CDN lifetime/i);
       expect(f!.message).not.toMatch(/no cache-control header/i);
+    });
+
+    it('names the header that is present when only cdn-cache-control lacks a lifetime', async () => {
+      const { 'cache-control': _, ...rest } = VERCEL_HIT;
+      const findings = await auditVercel(makeCtx({ headers: { ...rest, 'x-vercel-cache': 'MISS', 'cdn-cache-control': 'no-transform' } }));
+      const f = findings.find((x) => x.code === 'VERCEL_CACHE_CONTROL_MISSING');
+      expect(f!.message).toMatch(/no CDN lifetime in cdn-cache-control/i);
+      expect(f!.message).not.toMatch(/in cache-control/i);
     });
 
     it('warns on an empty cache-control after a miss', async () => {

--- a/src/audit/vercel.ts
+++ b/src/audit/vercel.ts
@@ -7,15 +7,30 @@ const S_MAXAGE_FLOOR = 60;
 
 const VERCEL_APP_SUFFIX = '.vercel.app';
 
+// <project>-git-<branch>-<scope>.vercel.app. A project whose own name contains "git" fits
+// this too, so the shape is a strong hint, not proof. Commit URLs carry a nine-character
+// hash label instead of a branch; a host with one of those is not read as a branch URL.
+const BRANCH_URL = /^[a-z0-9]+(?:-[a-z0-9]+)*-git-[a-z0-9]+(?:-[a-z0-9]+)*-[a-z0-9]+\.vercel\.app$/;
+const COMMIT_HASH_LABEL = /-(?=[a-z0-9]{9}-)(?=[a-z0-9]*\d)(?=[a-z0-9]*[a-z])[a-z0-9]{9}-/;
+
+function isBranchUrl(host: string): boolean {
+  return BRANCH_URL.test(host) && !COMMIT_HASH_LABEL.test(host.slice(host.indexOf('-git-') + 4));
+}
+
+// noindex, or none (which means noindex, nofollow).
+const NOINDEX = /\b(?:noindex|none)\b/i;
+
 type Directives = Map<string, string | true>;
 
 function parseDirectives(value: string | undefined): Directives | undefined {
   if (value === undefined) return undefined;
   const out: Directives = new Map();
   for (const part of value.split(',')) {
-    const [name, raw] = part.trim().split('=', 2);
+    const eq = part.indexOf('=');
+    const name = (eq === -1 ? part : part.slice(0, eq)).trim().toLowerCase();
     if (!name) continue;
-    out.set(name.toLowerCase(), raw === undefined ? true : raw.trim().replace(/^"|"$/g, ''));
+    const raw = eq === -1 ? true : part.slice(eq + 1).trim().replace(/^"|"$/g, '');
+    out.set(name, raw);
   }
   return out;
 }
@@ -24,6 +39,24 @@ function seconds(directives: Directives | undefined, name: string): number | und
   const raw = directives?.get(name);
   if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return undefined;
   return Number(raw);
+}
+
+interface Lifetime {
+  lifetime: number;
+  directive: 's-maxage' | 'max-age';
+  source: 'cdn-cache-control' | 'cache-control';
+}
+
+// Cache-Control only caches the CDN through s-maxage; CDN-Cache-Control also honours max-age.
+function lifetimeFrom(directives: Directives | undefined, source: Lifetime['source']): Lifetime | undefined {
+  if (!directives) return undefined;
+  const sMaxage = seconds(directives, 's-maxage');
+  if (sMaxage !== undefined) return { lifetime: sMaxage, directive: 's-maxage', source };
+  if (source === 'cdn-cache-control') {
+    const maxAge = seconds(directives, 'max-age');
+    if (maxAge !== undefined) return { lifetime: maxAge, directive: 'max-age', source };
+  }
+  return undefined;
 }
 
 // The CDN refuses to store these no matter what else is set.
@@ -64,22 +97,22 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
   const host = new URL(url).hostname.toLowerCase();
   if (host.endsWith(VERCEL_APP_SUFFIX)) {
     const xRobots = (headers['x-robots-tag'] ?? '').toLowerCase();
-    const headerNoindex = xRobots.includes('noindex');
+    const headerNoindex = NOINDEX.test(xRobots);
     const metaNoindex = ctx.html ? getNoindexDirective(ctx.html) : false;
     if (!headerNoindex && !metaNoindex) {
-      const isBranchUrl = host.includes('-git-');
+      const branchUrl = isBranchUrl(host);
       findings.push({
         code: 'VERCEL_PREVIEW_INDEXABLE',
-        severity: isBranchUrl ? 'error' : 'warning',
+        severity: branchUrl ? 'error' : 'warning',
         category: 'vercel',
-        message: isBranchUrl
+        message: branchUrl
           ? 'Branch preview deployment is indexable'
           : 'Generated vercel.app URL is indexable',
-        explanation: isBranchUrl
-          ? 'Vercel sends x-robots-tag: noindex on every preview deployment so it cannot compete with production for the same content. This branch URL sends neither the header nor a robots meta noindex, which happens when the header has been disabled in vercel.json or overwritten by middleware.'
+        explanation: branchUrl
+          ? 'This host has the shape of a branch preview URL. Vercel sends x-robots-tag: noindex on every preview deployment so it cannot compete with production for the same content, and this one sends neither the header nor a robots meta noindex, which happens when the header has been disabled in vercel.json or overwritten by middleware.'
           : 'This vercel.app URL sends no noindex. If it is the production deployment on its generated domain that is expected, but if it is a preview or an old deployment it duplicates your production content in the index.',
-        suggestion: isBranchUrl
-          ? 'Remove any vercel.json or middleware rule that drops x-robots-tag on previews, or add the header for non-production builds using the VERCEL_ENV variable.'
+        suggestion: branchUrl
+          ? 'Remove any vercel.json or middleware rule that drops x-robots-tag on previews, or add the header for non-production builds using the VERCEL_ENV variable. If the project name itself contains "git" and this is production, serve it from a custom domain instead.'
           : 'Serve production from a custom domain, or add x-robots-tag: noindex to non-production builds using the VERCEL_ENV variable.',
         details: { host, xRobotsTag: xRobots || undefined, metaNoindex },
         url,
@@ -131,23 +164,24 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
     });
   }
 
-  // 3. Lifetime directives. CDN-Cache-Control wins over Cache-Control, and Cache-Control is
-  // only forwarded verbatim when CDN-Cache-Control is present, so read what is actually visible.
-  const ttl = cdn ? seconds(cdn, 's-maxage') ?? seconds(cdn, 'max-age') : seconds(cc, 's-maxage');
-  const swr =
-    seconds(cdn, 'stale-while-revalidate') ?? seconds(cc, 'stale-while-revalidate');
+  // 3. Lifetime directives. CDN-Cache-Control wins over Cache-Control outright, so once it is
+  // present nothing in Cache-Control counts. Vercel usually consumes s-maxage before the
+  // client sees it, so a lifetime is only readable when it comes through.
+  const lifetime = cdn ? lifetimeFrom(cdn, 'cdn-cache-control') : lifetimeFrom(cc, 'cache-control');
+  const ttl = lifetime?.lifetime;
+  const swr = cdn ? cdn.has('stale-while-revalidate') : !!cc?.has('stale-while-revalidate');
 
-  if (status === 'MISS' && (cc === undefined || (cdn !== undefined && ttl === undefined))) {
+  if (status === 'MISS' && ttl === undefined) {
+    const noHeader = cc === undefined && cdn === undefined;
     findings.push({
       code: 'VERCEL_CACHE_CONTROL_MISSING',
       severity: 'warning',
       category: 'vercel',
-      message:
-        cc === undefined
-          ? 'No cache-control header on a page that missed the CDN cache'
-          : 'cdn-cache-control sets no lifetime on a page that missed the CDN cache',
+      message: noHeader
+        ? 'No cache-control header on a page that missed the CDN cache'
+        : 'No CDN lifetime in cache-control on a page that missed the CDN cache',
       explanation:
-        'Without s-maxage (or max-age in cdn-cache-control) the CDN generates this page on every request. Vercel treats the default as public, max-age=0, must-revalidate, which caches nothing.',
+        'Without s-maxage (or max-age in cdn-cache-control) the CDN generates this page on every request. Vercel treats the default public, max-age=0, must-revalidate as no caching. Vercel also strips s-maxage before the client sees it, so a cold miss straight after a deploy looks the same; a second run settles it.',
       suggestion:
         'For pages that are the same for every visitor, send Cache-Control: max-age=0, s-maxage=86400 with a stale-while-revalidate window, or use ISR.',
       details: cacheDetails,
@@ -155,7 +189,8 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
     });
   }
 
-  if (ttl !== undefined) {
+  // s-maxage=0 is a deliberate do-not-cache, not a short lifetime.
+  if (lifetime && ttl !== undefined && ttl > 0) {
     if (ttl < S_MAXAGE_FLOOR) {
       findings.push({
         code: 'VERCEL_S_MAXAGE_SHORT',
@@ -166,11 +201,11 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
           'A very short s-maxage sends most visitors to the origin. Vercel pairs short lifetimes with stale-while-revalidate so the CDN can keep serving while it refreshes in the background.',
         suggestion:
           'Raise s-maxage for content that tolerates staleness, or keep it short and add stale-while-revalidate (for example s-maxage=1, stale-while-revalidate=59).',
-        details: { ...cacheDetails, sMaxage: ttl, floor: S_MAXAGE_FLOOR },
+        details: { ...cacheDetails, ...lifetime, floor: S_MAXAGE_FLOOR },
         url,
       });
     }
-    if (swr === undefined) {
+    if (!swr) {
       findings.push({
         code: 'VERCEL_SWR_MISSING',
         severity: 'info',
@@ -179,7 +214,7 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
         explanation:
           'When s-maxage runs out the next visitor waits for the origin. With stale-while-revalidate the CDN serves the stale copy and refreshes it in the background.',
         suggestion: 'Add stale-while-revalidate=N alongside s-maxage.',
-        details: { ...cacheDetails, sMaxage: ttl },
+        details: { ...cacheDetails, ...lifetime },
         url,
       });
     }

--- a/src/audit/vercel.ts
+++ b/src/audit/vercel.ts
@@ -125,8 +125,10 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
   const cdnCacheControl = headers['cdn-cache-control'];
   const cc = parseDirectives(cacheControl);
   const cdn = parseDirectives(cdnCacheControl);
+  // CDN-Cache-Control overrides Cache-Control for the CDN, so a browser-only no-store beside
+  // a CDN lifetime is still storable.
   const personalised =
-    'set-cookie' in headers || optsOut(cc) || optsOut(cdn) || (headers['vary'] ?? '').trim() === '*';
+    'set-cookie' in headers || optsOut(cdn ?? cc) || (headers['vary'] ?? '').trim() === '*';
   if (personalised) return findings;
 
   const status = (headers['x-vercel-cache'] ?? '').toUpperCase();
@@ -172,14 +174,14 @@ export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
   const swr = cdn ? cdn.has('stale-while-revalidate') : !!cc?.has('stale-while-revalidate');
 
   if (status === 'MISS' && ttl === undefined) {
-    const noHeader = cc === undefined && cdn === undefined;
+    const present = [cdn && 'cdn-cache-control', cc && 'cache-control'].filter(Boolean).join(' or ');
     findings.push({
       code: 'VERCEL_CACHE_CONTROL_MISSING',
       severity: 'warning',
       category: 'vercel',
-      message: noHeader
-        ? 'No cache-control header on a page that missed the CDN cache'
-        : 'No CDN lifetime in cache-control on a page that missed the CDN cache',
+      message: present
+        ? `No CDN lifetime in ${present} on a page that missed the CDN cache`
+        : 'No cache-control header on a page that missed the CDN cache',
       explanation:
         'Without s-maxage (or max-age in cdn-cache-control) the CDN generates this page on every request. Vercel treats the default public, max-age=0, must-revalidate as no caching. Vercel also strips s-maxage before the client sees it, so a cold miss straight after a deploy looks the same; a second run settles it.',
       suggestion:

--- a/src/audit/vercel.ts
+++ b/src/audit/vercel.ts
@@ -1,0 +1,189 @@
+import type { AuditContext, AuditFinding } from '../types.js';
+import { getNoindexDirective } from '../utils/html-parser.js';
+
+// Vercel's own examples pair a one-second s-maxage with stale-while-revalidate. Below a
+// minute without it, every expiry makes a visitor wait on the origin.
+const S_MAXAGE_FLOOR = 60;
+
+const VERCEL_APP_SUFFIX = '.vercel.app';
+
+type Directives = Map<string, string | true>;
+
+function parseDirectives(value: string | undefined): Directives | undefined {
+  if (value === undefined) return undefined;
+  const out: Directives = new Map();
+  for (const part of value.split(',')) {
+    const [name, raw] = part.trim().split('=', 2);
+    if (!name) continue;
+    out.set(name.toLowerCase(), raw === undefined ? true : raw.trim().replace(/^"|"$/g, ''));
+  }
+  return out;
+}
+
+function seconds(directives: Directives | undefined, name: string): number | undefined {
+  const raw = directives?.get(name);
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return undefined;
+  return Number(raw);
+}
+
+// The CDN refuses to store these no matter what else is set.
+function optsOut(directives: Directives | undefined): boolean {
+  return !!directives && ['private', 'no-store', 'no-cache'].some((d) => directives.has(d));
+}
+
+/**
+ * Header-driven checks that only make sense on Vercel's CDN. Everything comes from the
+ * phase 0 response; nothing here makes a request of its own.
+ */
+export async function auditVercel(ctx: AuditContext): Promise<AuditFinding[]> {
+  const findings: AuditFinding[] = [];
+  const { normalizedUrl, headers } = ctx;
+  if (!headers) return findings;
+
+  const url = ctx.finalUrl ?? normalizedUrl;
+
+  const server = headers['server'] ?? '';
+  const xVercelId = headers['x-vercel-id'];
+  if (!server.toLowerCase().includes('vercel') && !xVercelId) {
+    findings.push({
+      code: 'NOT_ON_VERCEL',
+      severity: 'info',
+      category: 'vercel',
+      message: 'No Vercel signal in the response headers, Vercel checks skipped',
+      explanation:
+        'Vercel deployments answer with server: Vercel and an x-vercel-id header. Neither was present, so the cache and preview checks do not apply.',
+      suggestion: 'No action needed unless this site is on Vercel behind another proxy that rewrites the server header.',
+      details: { server: server || undefined },
+      url,
+    });
+    return findings;
+  }
+
+  // 1. Preview deployments must not be indexable. Branch URLs are always previews; the
+  // other generated shapes can also be the production deployment's own URL.
+  const host = new URL(url).hostname.toLowerCase();
+  if (host.endsWith(VERCEL_APP_SUFFIX)) {
+    const xRobots = (headers['x-robots-tag'] ?? '').toLowerCase();
+    const headerNoindex = xRobots.includes('noindex');
+    const metaNoindex = ctx.html ? getNoindexDirective(ctx.html) : false;
+    if (!headerNoindex && !metaNoindex) {
+      const isBranchUrl = host.includes('-git-');
+      findings.push({
+        code: 'VERCEL_PREVIEW_INDEXABLE',
+        severity: isBranchUrl ? 'error' : 'warning',
+        category: 'vercel',
+        message: isBranchUrl
+          ? 'Branch preview deployment is indexable'
+          : 'Generated vercel.app URL is indexable',
+        explanation: isBranchUrl
+          ? 'Vercel sends x-robots-tag: noindex on every preview deployment so it cannot compete with production for the same content. This branch URL sends neither the header nor a robots meta noindex, which happens when the header has been disabled in vercel.json or overwritten by middleware.'
+          : 'This vercel.app URL sends no noindex. If it is the production deployment on its generated domain that is expected, but if it is a preview or an old deployment it duplicates your production content in the index.',
+        suggestion: isBranchUrl
+          ? 'Remove any vercel.json or middleware rule that drops x-robots-tag on previews, or add the header for non-production builds using the VERCEL_ENV variable.'
+          : 'Serve production from a custom domain, or add x-robots-tag: noindex to non-production builds using the VERCEL_ENV variable.',
+        details: { host, xRobotsTag: xRobots || undefined, metaNoindex },
+        url,
+      });
+    }
+  }
+
+  // 2. CDN cache state. Only worth reading when the response is one the CDN may store.
+  const cacheControl = headers['cache-control'];
+  const cdnCacheControl = headers['cdn-cache-control'];
+  const cc = parseDirectives(cacheControl);
+  const cdn = parseDirectives(cdnCacheControl);
+  const personalised =
+    'set-cookie' in headers || optsOut(cc) || optsOut(cdn) || (headers['vary'] ?? '').trim() === '*';
+  if (personalised) return findings;
+
+  const status = (headers['x-vercel-cache'] ?? '').toUpperCase();
+  const cacheDetails = {
+    xVercelCache: status || undefined,
+    cacheControl,
+    cdnCacheControl,
+  };
+
+  if (status === 'MISS') {
+    findings.push({
+      code: 'VERCEL_CACHE_MISS',
+      severity: 'info',
+      category: 'vercel',
+      message: 'Page was not served from the Vercel CDN cache (x-vercel-cache: MISS)',
+      explanation:
+        'The CDN had nothing to serve and generated the response from your function. Vercel strips s-maxage before the client sees it, so a cold miss after a deploy and a page with no CDN lifetime look the same from outside.',
+      suggestion:
+        'Run the audit again. A second MISS on a page that is the same for every visitor means it is not being cached; set s-maxage (Vercel suggests max-age=0, s-maxage=86400) or use ISR.',
+      details: cacheDetails,
+      url,
+    });
+  } else if (status === 'STALE') {
+    findings.push({
+      code: 'VERCEL_CACHE_STALE',
+      severity: 'info',
+      category: 'vercel',
+      message: 'Page was served stale while the CDN refreshed it (x-vercel-cache: STALE)',
+      explanation:
+        'The cached copy had passed its lifetime, so the CDN served it and regenerated in the background. That is the normal stale-while-revalidate path, but it is also what you see when every revalidation fails and the last good copy keeps being served.',
+      suggestion:
+        'Check the runtime logs for a revalidation error on this path. If regeneration is healthy, no action needed.',
+      details: cacheDetails,
+      url,
+    });
+  }
+
+  // 3. Lifetime directives. CDN-Cache-Control wins over Cache-Control, and Cache-Control is
+  // only forwarded verbatim when CDN-Cache-Control is present, so read what is actually visible.
+  const ttl = cdn ? seconds(cdn, 's-maxage') ?? seconds(cdn, 'max-age') : seconds(cc, 's-maxage');
+  const swr =
+    seconds(cdn, 'stale-while-revalidate') ?? seconds(cc, 'stale-while-revalidate');
+
+  if (status === 'MISS' && (cc === undefined || (cdn !== undefined && ttl === undefined))) {
+    findings.push({
+      code: 'VERCEL_CACHE_CONTROL_MISSING',
+      severity: 'warning',
+      category: 'vercel',
+      message:
+        cc === undefined
+          ? 'No cache-control header on a page that missed the CDN cache'
+          : 'cdn-cache-control sets no lifetime on a page that missed the CDN cache',
+      explanation:
+        'Without s-maxage (or max-age in cdn-cache-control) the CDN generates this page on every request. Vercel treats the default as public, max-age=0, must-revalidate, which caches nothing.',
+      suggestion:
+        'For pages that are the same for every visitor, send Cache-Control: max-age=0, s-maxage=86400 with a stale-while-revalidate window, or use ISR.',
+      details: cacheDetails,
+      url,
+    });
+  }
+
+  if (ttl !== undefined) {
+    if (ttl < S_MAXAGE_FLOOR) {
+      findings.push({
+        code: 'VERCEL_S_MAXAGE_SHORT',
+        severity: 'info',
+        category: 'vercel',
+        message: `CDN lifetime is ${ttl}s (below ${S_MAXAGE_FLOOR}s)`,
+        explanation:
+          'A very short s-maxage sends most visitors to the origin. Vercel pairs short lifetimes with stale-while-revalidate so the CDN can keep serving while it refreshes in the background.',
+        suggestion:
+          'Raise s-maxage for content that tolerates staleness, or keep it short and add stale-while-revalidate (for example s-maxage=1, stale-while-revalidate=59).',
+        details: { ...cacheDetails, sMaxage: ttl, floor: S_MAXAGE_FLOOR },
+        url,
+      });
+    }
+    if (swr === undefined) {
+      findings.push({
+        code: 'VERCEL_SWR_MISSING',
+        severity: 'info',
+        category: 'vercel',
+        message: 'CDN lifetime is set without stale-while-revalidate',
+        explanation:
+          'When s-maxage runs out the next visitor waits for the origin. With stale-while-revalidate the CDN serves the stale copy and refreshes it in the background.',
+        suggestion: 'Add stale-while-revalidate=N alongside s-maxage.',
+        details: { ...cacheDetails, sMaxage: ttl },
+        url,
+      });
+    }
+  }
+
+  return findings;
+}

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -18,6 +18,7 @@ vi.mock('./audit/index.js', () => ({
   auditImages: vi.fn(),
   auditSecurity: vi.fn(),
   auditPerformance: vi.fn(),
+  auditVercel: vi.fn(),
 }));
 
 import { fetchPage } from './utils/http.js';
@@ -34,6 +35,7 @@ import {
   auditImages,
   auditSecurity,
   auditPerformance,
+  auditVercel,
 } from './audit/index.js';
 
 const mockFetchPage = vi.mocked(fetchPage);
@@ -49,6 +51,7 @@ const mockI18n = vi.mocked(auditI18n);
 const mockImages = vi.mocked(auditImages);
 const mockSecurity = vi.mocked(auditSecurity);
 const mockPerformance = vi.mocked(auditPerformance);
+const mockVercel = vi.mocked(auditVercel);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -73,6 +76,7 @@ beforeEach(() => {
   mockImages.mockResolvedValue([]);
   mockSecurity.mockResolvedValue([]);
   mockPerformance.mockResolvedValue([]);
+  mockVercel.mockResolvedValue([]);
 });
 
 describe('runAudit', () => {
@@ -93,7 +97,7 @@ describe('runAudit', () => {
     expect(mockRedirects).toHaveBeenCalledTimes(1);
   });
 
-  it('runs phase 2 modules (sitemap, metadata, favicon, nextjs, structuredData, i18n, images, security, performance)', async () => {
+  it('runs phase 2 modules (sitemap, metadata, favicon, nextjs, structuredData, i18n, images, security, performance, vercel)', async () => {
     await runAudit('https://example.com');
 
     expect(mockSitemap).toHaveBeenCalledTimes(1);
@@ -105,6 +109,7 @@ describe('runAudit', () => {
     expect(mockImages).toHaveBeenCalledTimes(1);
     expect(mockSecurity).toHaveBeenCalledTimes(1);
     expect(mockPerformance).toHaveBeenCalledTimes(1);
+    expect(mockVercel).toHaveBeenCalledTimes(1);
   });
 
   it('does not run crawl module when crawl option is not set', async () => {
@@ -222,6 +227,7 @@ describe('runAudit', () => {
     expect(names).toContain('images');
     expect(names).toContain('security');
     expect(names).toContain('performance');
+    expect(names).toContain('vercel');
   });
 
   it('fetches the page once up front and shares it with every module', async () => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -20,6 +20,7 @@ import {
   auditImages,
   auditSecurity,
   auditPerformance,
+  auditVercel,
 } from './audit/index.js';
 
 type AuditModule = {
@@ -42,6 +43,7 @@ const phase2Modules: AuditModule[] = [
   { name: 'images', run: auditImages },
   { name: 'security', run: auditSecurity },
   { name: 'performance', run: auditPerformance },
+  { name: 'vercel', run: auditVercel },
 ];
 
 async function runModules(

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export type IssueCategory =
   | 'i18n'
   | 'images'
   | 'security'
-  | 'performance';
+  | 'performance'
+  | 'vercel';
 
 export type IssueCode =
   // Redirect issues
@@ -111,7 +112,15 @@ export type IssueCode =
   | 'HTML_SIZE_WARNING'
   | 'RENDER_BLOCKING_SCRIPT'
   | 'LARGE_INLINE_STYLE'
-  | 'MISSING_PRECONNECT';
+  | 'MISSING_PRECONNECT'
+  // Vercel platform issues
+  | 'NOT_ON_VERCEL'
+  | 'VERCEL_CACHE_MISS'
+  | 'VERCEL_CACHE_STALE'
+  | 'VERCEL_CACHE_CONTROL_MISSING'
+  | 'VERCEL_S_MAXAGE_SHORT'
+  | 'VERCEL_SWR_MISSING'
+  | 'VERCEL_PREVIEW_INDEXABLE';
 
 export interface AuditFinding {
   code: IssueCode;

--- a/src/utils/html-parser.test.ts
+++ b/src/utils/html-parser.test.ts
@@ -67,6 +67,15 @@ describe('getNoindexDirective', () => {
     expect(getNoindexDirective(html('<meta name="GoogleBot" content="noindex">'))).toBe(true);
   });
 
+  it('treats none as noindex', () => {
+    expect(getNoindexDirective(html('<meta name="robots" content="none">'))).toBe(true);
+    expect(getNoindexDirective(html('<meta name="googlebot" content="NONE, nosnippet">'))).toBe(true);
+  });
+
+  it('does not match none inside another word', () => {
+    expect(getNoindexDirective(html('<meta name="robots" content="nonexistent"><meta name="googlebot" content="all"><meta name="robots" content="index, follow"><meta name="robots" content="noneed">'))).toBe(false);
+  });
+
   it('ignores other meta names that mention noindex', () => {
     expect(getNoindexDirective(html('<meta name="description" content="noindex">'))).toBe(false);
   });

--- a/src/utils/html-parser.test.ts
+++ b/src/utils/html-parser.test.ts
@@ -61,6 +61,15 @@ describe('getNoindexDirective', () => {
   it('is case-insensitive', () => {
     expect(getNoindexDirective(html('<meta name="robots" content="NOINDEX">'))).toBe(true);
   });
+
+  it('matches the meta name case-insensitively', () => {
+    expect(getNoindexDirective(html('<meta name="ROBOTS" content="noindex">'))).toBe(true);
+    expect(getNoindexDirective(html('<meta name="GoogleBot" content="noindex">'))).toBe(true);
+  });
+
+  it('ignores other meta names that mention noindex', () => {
+    expect(getNoindexDirective(html('<meta name="description" content="noindex">'))).toBe(false);
+  });
 });
 
 describe('getMetaRefresh', () => {

--- a/src/utils/html-parser.ts
+++ b/src/utils/html-parser.ts
@@ -14,7 +14,8 @@ export function getNoindexDirective(html: string): boolean {
     .some((el) => {
       const name = ($(el).attr('name') ?? '').trim().toLowerCase();
       if (name !== 'robots' && name !== 'googlebot') return false;
-      return ($(el).attr('content') ?? '').toLowerCase().includes('noindex');
+      // none means noindex, nofollow
+      return /\b(?:noindex|none)\b/i.test($(el).attr('content') ?? '');
     });
 }
 

--- a/src/utils/html-parser.ts
+++ b/src/utils/html-parser.ts
@@ -8,10 +8,14 @@ export function getCanonicalUrl(html: string): string | null {
 
 export function getNoindexDirective(html: string): boolean {
   const $ = cheerio.load(html);
-  const robotsMeta = $('meta[name="robots"]').attr('content') ?? '';
-  const googlebotMeta = $('meta[name="googlebot"]').attr('content') ?? '';
-  const combined = `${robotsMeta} ${googlebotMeta}`.toLowerCase();
-  return combined.includes('noindex');
+  // Attribute selectors are case-sensitive; crawlers are not.
+  return $('meta[name]')
+    .toArray()
+    .some((el) => {
+      const name = ($(el).attr('name') ?? '').trim().toLowerCase();
+      if (name !== 'robots' && name !== 'googlebot') return false;
+      return ($(el).attr('content') ?? '').toLowerCase().includes('noindex');
+    });
 }
 
 export function getMetaRefresh(html: string): string | null {


### PR DESCRIPTION
the one thing a generic seo cli can't do is read what vercel's edge is telling you, and the tool already had the response headers in hand. new `vercel` module, all from the phase 0 fetch, no extra requests.

what it reports: not on vercel (once, then the rest is skipped), x-vercel-cache MISS or STALE on a response that could have been cached, no readable cdn lifetime after a miss (vercel's default `public, max-age=0, must-revalidate` is exactly that), s-maxage under 60s, no stale-while-revalidate next to a lifetime, and a `*.vercel.app` url that isn't sending noindex (error when it has the branch preview shape, warning otherwise). every rule points at the vercel doc it comes from, cdn-cache-control wins over cache-control the way the docs say, s-maxage=0 counts as on purpose.

miss and stale are info, a cold miss looks the same from outside as never cached so they can't fail --strict.

also fixed on the way: robots meta with content="none" and upper-case meta names weren't read as noindex anywhere in the tool.

readme gets the module and a "what this does not do" section. 463 tests, 66 new.
