### PR TITLE
ci: move the v<major> tag on every release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,3 +62,33 @@ jobs:
           else
             npm publish --provenance --access public
           fi
+
+  # The Marketplace example says `uses: JosephDoUrden/vercel-seo-audit@v1`. That tag only means
+  # something if it follows releases, so after every publish the v<major> tag is moved to the
+  # release commit. Moved through the API, so it is a plain tag, not a signed one, same as the
+  # major tags on actions/checkout and friends.
+  move-major-tag:
+    needs: [release-please, publish]
+    if: needs.release-please.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Point v<major> at this release
+        run: |
+          MAJOR=$(node -p "require('./package.json').version.split('.')[0]")
+          TAG="v${MAJOR}"
+          if gh api "repos/${REPO}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/tags/${TAG}" -f sha="${SHA}" -F force=true >/dev/null
+            echo "moved ${TAG} to ${SHA}"
+          else
+            gh api -X POST "repos/${REPO}/git/refs" -f ref="refs/tags/${TAG}" -f sha="${SHA}" >/dev/null
+            echo "created ${TAG} at ${SHA}"
+          fi

--- a/README.md
+++ b/README.md
@@ -304,7 +304,8 @@ jobs:
           report: json
 ```
 
-The pinned tag is updated on each release.
+The pinned tag above is updated on each release. `@v2` also works and follows the latest 2.x release; a
+workflow moves it after every publish. For a build that never changes underneath you, pin the commit SHA.
 
 All inputs:
 

--- a/site/index.html
+++ b/site/index.html
@@ -697,7 +697,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: JosephDoUrden/vercel-seo-audit@vercel-seo-audit-v2.5.0
+      - uses: JosephDoUrden/vercel-seo-audit@v2
         with:
           url: https://your-site.com
           strict: true


### PR DESCRIPTION
the marketplace example pins a floating major tag and that tag had been sitting on february's commit since the action was added. after each publish a job now points v<major> at the release commit through the api, lightweight and unsigned, which is how the official actions do theirs. package is 2.x so the tag is v2; readme explains it and the site example uses it. v1 stays as it is for now.